### PR TITLE
Auto-merge dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,3 +3,7 @@ update_configs:
   - package_manager: "java:maven"
     directory: "/"
     update_schedule: "daily"
+    automerged_updates:
+      - match:
+          dependency_type: "production"
+          update_type: "all"


### PR DESCRIPTION
## Description
To reduce burden on the develops we can auto bump and merge. The
concurrency policy has been set to 1 on this CI pipeline to avoid
clashes in the release.json

## Impacted Areas in Application
List general components of the application that this PR will affect:

* versioning


