### PR TITLE
Use latest parent pom to fix #81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.57</version>
+        <version>1.0.58</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.58</version>
+        <version>1.0.60</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
- Need to update the version of parent pom to pick up the latest version
of spring-security-multi-auth-starter.version which uses latest
eidas-psd2-sdk version.
- Fixes https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/81

