### PR TITLE
Use the openbanking-uk-datamodel binaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.56</ob-common.version>
+        <ob-common.version>1.0.64</ob-common.version>
         <ob-analytics.version>1.1.35</ob-analytics.version>
         <ob-jwkms.version>1.1.52</ob-jwkms.version>
         <ob-auth.version>1.0.55</ob-auth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.60</version>
+        <version>1.0.62</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,13 +45,12 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.64</ob-common.version>
         <ob-analytics.version>1.1.35</ob-analytics.version>
         <ob-jwkms.version>1.1.52</ob-jwkms.version>
         <ob-auth.version>1.0.55</ob-auth.version>
         <ob-directory.version>1.4.48</ob-directory.version>
         <ob-auth.version>1.0.53</ob-auth.version>
-        <ob-aspsp.version>1.0.55</ob-aspsp.version>
+        <ob-aspsp.version>1.0.60</ob-aspsp.version>
         <ob-clients.version>1.0.23</ob-clients.version>
     </properties>
 


### PR DESCRIPTION
Use the openbanking-uk-datamodel binaries
    
    - The openbanking reference impementation and dependent code was using
    the openbanking-sdk library from the Github ForgeRock organisation. It
    should be using the openbanking-uk-datamodel repo from Github
    OpenBankingToolkit org.
    - This involved updating the latest openbanking-aspsp and parent pom
    versions
    - See https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/5
