### PR TITLE
Use the trace ID as interaction ID

### DIFF
--- a/forgerock-openbanking-gateway/src/main/java/com/forgerock/openbanking/gateway/filters/AddInteractionIdHeaderGatewayFilter.java
+++ b/forgerock-openbanking-gateway/src/main/java/com/forgerock/openbanking/gateway/filters/AddInteractionIdHeaderGatewayFilter.java
@@ -54,7 +54,7 @@ public class AddInteractionIdHeaderGatewayFilter implements GatewayFilter {
         String xFapiInteractionId = request.getHeaders().getFirst(X_FAPI_INTERACTION_ID_HEADER_NAME);
         if (StringUtils.isEmpty(xFapiInteractionId)) {
             log.debug("Interaction ID is missing, generate ID '{}'", xFapiInteractionId);
-            xFapiInteractionId = UUID.randomUUID().toString();
+            xFapiInteractionId = tracer.currentSpan().context().traceIdString();
         }
         try{
             UUID.fromString(xFapiInteractionId);


### PR DESCRIPTION
After battling for I don't know how many times, it sounds like in the latest version of spring, they did extend the tracer object to return the trace ID (finally!)
I was probably not the only one get frustrated not been able to get this value.

Anyway, if you upgrade to the latest spring, I guess this PR will compile and your support investigation would be simplified slightly :)
