### PR TITLE
Fix test scope integration test support

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -76,6 +76,7 @@
         <dependency>
             <groupId>com.forgerock.openbanking.aspsp</groupId>
             <artifactId>integration-test-support</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.jsonzou</groupId>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -84,6 +84,7 @@
         <dependency>
             <groupId>com.forgerock.openbanking.aspsp</groupId>
             <artifactId>integration-test-support</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.jsonzou</groupId>


### PR DESCRIPTION
## Description
Use de integration test support dependency only in test scope to avoid spring conflicts with mocked objects such as WebSecurityConfigAdapter.

## Impacted Areas in Application
Integration Test and Funcional Test.


