### PR TITLE
Fix the supported media type issue, filter deleted

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsApiController.java
@@ -158,7 +158,6 @@ public class CSVFilePaymentConsentsApiController {
                 .principal(principal)
                 .filters(f -> {
                     f.verifyFileHash(fileParam);
-                    f.verifyContentTypeHeader(contentTypeOfFile);
                     f.verifyIdempotencyKeyLength(xIdempotencyKey);
                 })
                 .execute(


### PR DESCRIPTION
## Description
Fix error with the content type when we validate the supported media type using an extension media types from Spring, for that csv file type case to avoid the content type validation we remove the filter on that csv specific controller.
@see CSVFilePaymentConsentsApiController#csvCreateFilePaymentConsentsConsentIdFile
@see FilePaymentsApiEndpointWrapper#verifyContentTypeHeader

## Impacted Areas in Application
List general components of the application that this PR will affect:

* CSV Files requirement


