### PR TITLE
Fix to mapping correctly the consume 

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsApiController.java
@@ -95,8 +95,7 @@ public class CSVFilePaymentConsentsApiController {
     )
     @RequestMapping(value = "/file-payment-consents/{ConsentId}/file",
             produces = {"application/json; charset=utf-8"},
-            headers = {"Content-Type=text/csv"},
-            consumes = {"*/*"},
+            consumes = {"text/csv; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<Void> csvCreateFilePaymentConsentsConsentIdFile(
             @ApiParam(value = "Default", required = true)

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -161,14 +161,12 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         MvcResult result = mockMvc.perform(
                 MockMvcRequestBuilders
                         .post("https://rs-api:" + port + _url, fileConsentId)
-                        .accept(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
                         .contentType("text/csv")
                         .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                         .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
                         .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                         .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
-                        .header(CONTENT_TYPE, "text/csv")
-                        .header(ACCEPT, "application/json")
                         .header("x-ob-client-id", "pispId123")
                         .content(file.toString()))
                 .andExpect(status().isCreated())
@@ -202,14 +200,12 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         MvcResult result = mockMvc.perform(
                 MockMvcRequestBuilders
                         .post("https://rs-api:" + port + _url, fileConsentId)
-                        .accept(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
                         .contentType("text/csv")
                         .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                         .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
                         .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                         .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
-                        .header(CONTENT_TYPE, "text/csv")
-                        .header(ACCEPT, "application/json")
                         .header("x-ob-client-id", "pispId123")
                         .content(file.toString()))
                 .andExpect(status().isCreated())

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/CSVFilePaymentConsentsRsStoreApiController.java
@@ -101,8 +101,7 @@ public class CSVFilePaymentConsentsRsStoreApiController {
     )
     @RequestMapping(value = "/file-payment-consents/{ConsentId}/file",
             produces = {"application/json; charset=utf-8"},
-            headers = {"Content-Type=text/csv"},
-            consumes = {"*/*"},
+            consumes = {"text/csv; charset=utf-8"},
             method = RequestMethod.POST)
     ResponseEntity<Void> csvCreateFilePaymentConsentsConsentIdFile(
             @ApiParam(value = "Default", required = true)

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -53,6 +53,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.org.openbanking.OBHeaders;
@@ -165,12 +166,12 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
 
         // When
         HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
                 .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
                 .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
-                .header(ACCEPT, "application/json")
                 .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
                 .body(file.toString())
                 .asString();
@@ -204,12 +205,12 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
 
         // When
         HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
                 .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
                 .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
-                .header(ACCEPT, "application/json")
                 .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
                 .body(file.toString())
                 .asString();
@@ -234,12 +235,12 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
         HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
                 .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
                 .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
-                .header(ACCEPT, "application/json")
                 .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
                 .body("csvFileContent")
                 .asJson();
@@ -264,12 +265,12 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
         HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
                 .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
                 .header(CONTENT_TYPE, "CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType()")
-                .header(ACCEPT, "application/json")
                 .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
                 .body("csvFileContent")
                 .asJson();
@@ -301,12 +302,12 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         repository.save(existingConsent);
 
         HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
                 .header(OBHeaders.X_FAPI_FINANCIAL_ID, rsConfiguration.financialId)
                 .header(OBHeaders.AUTHORIZATION, "token")
                 .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
                 .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
                 .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
-                .header(ACCEPT, "application/json")
                 .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
                 .body("csvFileContent")
                 .asJson();


### PR DESCRIPTION
## Description
Change the request mapping to set the consume for text/csv media type.
This fix void error the ambiguous handler method mapping when some xml or json consume the submit.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* File payments


