### PR TITLE
Set mvn version to 3.1.2-smiths-SNAPSHOT

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-     <version>3.1.2-queen-rc4</version>
+     <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp.rs</groupId>
 		<artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.aspsp.rs</groupId>
 		<artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-     <version>3.1.2-queen-rc4</version>
+     <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-     <version>3.1.2-queen-rc4</version>
+     <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.backstage</groupId>
 		<artifactId>forgerock-openbanking-backstage</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.metrics</groupId>
 		<artifactId>forgerock-openbanking-metrics</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>3.1.2-queen-rc4</version>
+    <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-     <version>3.1.2-queen-rc4</version>
+     <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>3.1.2-queen-rc4</version>
+         <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.devportal</groupId>
 		<artifactId>forgerock-openbanking-devportal</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking.devportal</groupId>
 		<artifactId>forgerock-openbanking-devportal</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>3.1.2-queen-rc4</version>
+    <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -34,7 +34,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking</groupId>
 		<artifactId>forgerock-openbanking-reference-implementation</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -35,7 +35,7 @@
 	<parent>
 		<groupId>com.forgerock.openbanking</groupId>
 		<artifactId>forgerock-openbanking-reference-implementation</artifactId>
-		<version>3.1.2-queen-rc4</version>
+		<version>3.1.2-smiths-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.2-queen-rc4</version>
+        <version>3.1.2-smiths-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>3.1.2-queen-rc4</version>
+    <version>3.1.2-smiths-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
Part of https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/148
Set to smiths as we have missed REM timescales
