### PR TITLE
Non-default authorities from AM JWT authentication cookie

### DIFF
--- a/forgerock-openbanking-directory-services/src/main/java/com/forgerock/openbanking/directory/ForgerockOpenbankingDirectoryApplication.java
+++ b/forgerock-openbanking-directory-services/src/main/java/com/forgerock/openbanking/directory/ForgerockOpenbankingDirectoryApplication.java
@@ -213,11 +213,11 @@ public class ForgerockOpenbankingDirectoryApplication {
             Set<GrantedAuthority> authorities = Sets.newHashSet(
                     OBRIRole.ROLE_SOFTWARE_STATEMENT,
                     OBRIRole.ROLE_USER);
-            List<String> AMGroups = token.getJWTClaimsSet().getStringListClaim("group");
-            if (AMGroups != null && !AMGroups.isEmpty()) {
-                log.trace("AM Authorities founds: {}", AMGroups);
-                for (String AMgroup : AMGroups) {
-                    authorities.add(new SimpleGrantedAuthority(AMgroup));
+            List<String> amGroups = token.getJWTClaimsSet().getStringListClaim("group");
+            if (amGroups != null && !amGroups.isEmpty()) {
+                log.trace("AM Authorities founds: {}", amGroups);
+                for (String amGroup : amGroups) {
+                    authorities.add(new SimpleGrantedAuthority(amGroup));
                 }
             }
             return authorities;


### PR DESCRIPTION
> When using a GrantedAuthority directly, such as through the use of an expression like hasAuthority(‘READ_AUTHORITY'), we are restricting the API access in a fine-grained manner.

https://github.com/ForgeCloud/ob-deploy/issues/458

**To set the non-default authority to give access to the user over these protected APIs by specific Authority we need**:

- Collect additional authorities from AM JWT authentication cookie.
- To give user access to restricted APIs protected by authorities in fine-grained manner.
- Avoid give default access to these restricted APIs protected by specific authorities.

## Description
* Adding the default authorities.
* Adding the authorities coming from Forgerock AM JWT Cookie authentication if exist authorities.
* FYI: Additional Authorities setted on Claim 'group' set in 'identity / MSISDN Number'.

## Impacted Areas in Application
Fine-graned protected APIs by authorities on Directory.

## Configuration: Set the additional authorities

- With admin user on AM go to realm Auth and search the identity on you want give it the specific Authority.
- In the field form 'MSISDN Number' set your specific Authorities.