### PR TITLE
Reference images in GCR instead of CFCR

### DIFF
--- a/codefresh-release.yml
+++ b/codefresh-release.yml
@@ -38,7 +38,7 @@ steps:
          - ENFORCE_ADMINS=false      
    set-ob-ui-version:
       title: set ob-ui package version
-      image: r.cfcr.io/openbanking/forgecloud/openbanking/obdeployhelper:master
+      image: eu.gcr.io/openbanking-214714/forgecloud/openbanking/obdeployhelper:master
       stage: ob-ui
       commands:
          - ./ci/release-a-package.sh ob-ui .
@@ -69,7 +69,7 @@ steps:
          - ENFORCE_ADMINS=false
    set-ob-analytics-version:
       title: set ob-analytics package version
-      image: r.cfcr.io/openbanking/forgecloud/openbanking/obdeployhelper:master
+      image: eu.gcr.io/openbanking-214714/forgecloud/openbanking/obdeployhelper:master
       stage: ob-analytics
       commands:
          - ./ci/release-a-package.sh ob-analytics ./forgerock-openbanking-analytics-ui
@@ -93,7 +93,7 @@ steps:
        - ENFORCE_ADMINS=false
    set-ob-reference-implemenation-version:
       title: set ob-analytics package version
-      image: r.cfcr.io/openbanking/ob-release:latest
+      image: eu.gcr.io/openbanking-214714/ob-release:latest
       stage: openbanking-reference-implementation
       commands:
          - ./ci/release-mvn-project.sh openbanking-reference-implementation

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -329,90 +329,105 @@ steps:
         candidate: ${{build-config-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-docs-docker-image-latest:
         type: push
         title: "Push docs service docker image to registry"
         candidate: ${{build-docs-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-register-docker-image-latest:
         type: push
         title: "Push register service docker image to registry"
         candidate: ${{build-register-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-directory-docker-image-latest:
         type: push
         title: "Push directory service docker image to registry"
         candidate: ${{build-directory-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-jwkms-image-latest:
         type: push
         title: "Push jwkms service docker image to registry"
         candidate: ${{build-jwkms-image}}
         tags:
           - latest
+        registry: gcr
       push-as-api-docker-image-latest:
         type: push
         title: "Push as-api service docker image to registry"
         candidate: ${{build-as-api-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-rs-api-docker-image-latest:
         type: push
         title: "Push rs-api service docker image to registry"
         candidate: ${{build-rs-api-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-rs-rcs-docker-image-latest:
         type: push
         title: "Push rs-rcs service docker image to registry"
         candidate: ${{build-rs-rcs-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-rs-simulator-docker-image-latest:
         type: push
         title: "Push rs-simulator service docker image to registry"
         candidate: ${{build-rs-simulator-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-rs-store-docker-image-latest:
         type: push
         title: "Push rs-store service docker image to registry"
         candidate: ${{build-rs-store-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-rs-ui-docker-image-latest:
         type: push
         title: "Push rs-ui service docker image to registry"
         candidate: ${{build-rs-ui-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-admin-docker-image-latest:
         type: push
         title: "Push admin service docker image to registry"
         candidate: ${{build-admin-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-metrics-service-docker-image-latest:
         type: push
         title: "Push metrics service docker image to registry"
         candidate: ${{build-metrics-service-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-monitoring-service-docker-image-latest:
         type: push
         title: "Push monitoring service docker image to registry"
         candidate: ${{build-monitoring-service-docker-image}}
         tags:
           - latest
+        registry: gcr
       push-scgw-docker-image-latest:
         type: push
         title: "Push SCGW service docker image to registry"
         candidate: ${{build-scgw-docker-image}}
         tags:
           - latest
+        registry: gcr
     when:
       branch:
         only:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -78,7 +78,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-docs-docker-image:
         type: build
         title: "Build docs service docker image"
@@ -89,7 +89,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-register-docker-image:
         type: build
         title: "Build register service docker image"
@@ -100,7 +100,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-directory-docker-image:
         type: build
         title: "Build directory service docker image"
@@ -111,7 +111,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-jwkms-image:
         type: build
         title: "Build jwkms service docker image"
@@ -122,7 +122,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-as-api-docker-image:
         type: build
         title: "Build as-api service docker image"
@@ -133,7 +133,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-rs-api-docker-image:
         type: build
         title: "Build rs-api service docker image"
@@ -144,7 +144,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-rs-rcs-docker-image:
         type: build
         title: "Build rs-rcs service docker image"
@@ -155,7 +155,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-rs-simulator-docker-image:
         type: build
         title: "Build rs-simulator service docker image"
@@ -166,7 +166,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
   docker-build-2:
     type: parallel
     stage: "docker-build"
@@ -181,7 +181,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-rs-ui-docker-image:
         type: build
         title: "Build rs-ui service docker image"
@@ -192,7 +192,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-admin-docker-image:
         type: build
         title: "Build admin service docker image"
@@ -203,7 +203,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-metrics-service-docker-image:
         type: build
         title: "Build metrics service docker image"
@@ -214,7 +214,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-monitoring-service-docker-image:
         type: build
         title: "Build monitoring service docker image"
@@ -225,7 +225,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
       build-scgw-docker-image:
         type: build
         title: "Build scgw service docker image"
@@ -236,7 +236,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-
+        disable_push: true
 
   integration-test-scgw:
     type: composition

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -33,8 +33,9 @@ steps:
     environment: *global_env
     commands:
       - cf_export PROJECT_VERSION=$(mvn -Dmaven.repo.local=/codefresh/volume/${{CF_BRANCH_TAG_NORMALIZED}}/.m2/repository -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | tr '[:upper:]' '[:lower:]')
+      - cf_export REGISTRY_CONTEXT=${{REGISTRY_CONTEXT}}
   check-copyright:
-    image: eu.gcr.io/openbanking-214714/ob-release:latest
+    image: ${{REGISTRY_CONTEXT}}/ob-release:latest
     stage: "prepare"
     title: "Verify copyrights"
     working-directory: ${{main_clone}}
@@ -45,7 +46,7 @@ steps:
   build-stage:
     stage: "build"
     steps:
-    image: eu.gcr.io/openbanking-214714/ob-release:latest
+    image: ${{REGISTRY_CONTEXT}}/ob-release:latest
     title: "Compile, build and install artifact"
     working-directory: ${{main_clone}}
     environment: *global_env
@@ -56,7 +57,7 @@ steps:
     stage: "unit-test"
     steps:
     # Unit-test stage
-    image: eu.gcr.io/openbanking-214714/ob-release:latest
+    image: ${{REGISTRY_CONTEXT}}/ob-release:latest
     title: "Run unit tests"
     working-directory: ${{main_clone}}
     environment: *global_env
@@ -71,7 +72,7 @@ steps:
       build-config-docker-image:
         type: build
         title: "Build config service docker image"
-        image_name: obri/config
+        image_name: ${{REGISTRY_CONTEXT}}/obri/config
         working-directory: ${{main_clone}}/forgerock-openbanking-config
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -82,7 +83,7 @@ steps:
       build-docs-docker-image:
         type: build
         title: "Build docs service docker image"
-        image_name: obri/docs
+        image_name: ${{REGISTRY_CONTEXT}}/obri/docs
         working-directory: ${{main_clone}}/forgerock-openbanking-devportal/forgerock-openbanking-docs
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -93,7 +94,7 @@ steps:
       build-register-docker-image:
         type: build
         title: "Build register service docker image"
-        image_name: obri/register
+        image_name: ${{REGISTRY_CONTEXT}}/obri/register
         working-directory: ${{main_clone}}/forgerock-openbanking-devportal/forgerock-openbanking-register
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -104,7 +105,7 @@ steps:
       build-directory-docker-image:
         type: build
         title: "Build directory service docker image"
-        image_name: obri/directory-services
+        image_name: ${{REGISTRY_CONTEXT}}/obri/directory-services
         working-directory: ${{main_clone}}/forgerock-openbanking-directory-services
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -115,7 +116,7 @@ steps:
       build-jwkms-image:
         type: build
         title: "Build jwkms service docker image"
-        image_name: obri/jwkms
+        image_name: ${{REGISTRY_CONTEXT}}/obri/jwkms
         working-directory: ${{main_clone}}/forgerock-openbanking-jwkms
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -126,7 +127,7 @@ steps:
       build-as-api-docker-image:
         type: build
         title: "Build as-api service docker image"
-        image_name: obri/as-api
+        image_name: ${{REGISTRY_CONTEXT}}/obri/as-api
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -137,7 +138,7 @@ steps:
       build-rs-api-docker-image:
         type: build
         title: "Build rs-api service docker image"
-        image_name: obri/rs-api
+        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-api
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -148,7 +149,7 @@ steps:
       build-rs-rcs-docker-image:
         type: build
         title: "Build rs-rcs service docker image"
-        image_name: obri/rs-rcs
+        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-rcs
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -159,7 +160,7 @@ steps:
       build-rs-simulator-docker-image:
         type: build
         title: "Build rs-simulator service docker image"
-        image_name: obri/rs-simulator
+        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-simulator
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -174,7 +175,7 @@ steps:
       build-rs-store-docker-image:
         type: build
         title: "Build rs-store service docker image"
-        image_name: obri/rs-store
+        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-store
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -185,7 +186,7 @@ steps:
       build-rs-ui-docker-image:
         type: build
         title: "Build rs-ui service docker image"
-        image_name: obri/rs-ui
+        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-ui
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -196,7 +197,7 @@ steps:
       build-admin-docker-image:
         type: build
         title: "Build admin service docker image"
-        image_name: obri/admin
+        image_name: ${{REGISTRY_CONTEXT}}/obri/admin
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-admin
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -207,7 +208,7 @@ steps:
       build-metrics-service-docker-image:
         type: build
         title: "Build metrics service docker image"
-        image_name: obri/metrics-service
+        image_name: ${{REGISTRY_CONTEXT}}/obri/metrics-service
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -218,7 +219,7 @@ steps:
       build-monitoring-service-docker-image:
         type: build
         title: "Build monitoring service docker image"
-        image_name: obri/monitoring
+        image_name: ${{REGISTRY_CONTEXT}}/obri/monitoring
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-monitoring
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -251,7 +252,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: eu.gcr.io/openbanking-214714/ob-release:latest
+        image: ${{REGISTRY_CONTEXT}}/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-gateway/pom.xml
         # Simulate DNS routing multiple hostnames
@@ -278,7 +279,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: eu.gcr.io/openbanking-214714/ob-release:latest
+        image: ${{REGISTRY_CONTEXT}}/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
         # Simulate DNS routing multiple hostnames
@@ -306,7 +307,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: eu.gcr.io/openbanking-214714/ob-release:latest
+        image: ${{REGISTRY_CONTEXT}}/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
         # Simulate DNS routing multiple hostnames

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -247,6 +247,7 @@ steps:
     composition: docker-compose.yml
     composition_variables:
       - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+      - IMAGE=${{build-scgw-docker-image}}
     working_directory: ${{main_clone}}/forgerock-openbanking-gateway
     composition_candidates:
       scgw-tests:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,14 +27,14 @@ steps:
     git: github-bot
   #  Prepare stage
   set-global-variables:
-    image: r.cfcr.io/openbanking/ob-release:latest
+    image: eu.gcr.io/openbanking-214714/ob-release:latest
     stage: "prepare"
     title: "Set up global variables"
     environment: *global_env
     commands:
       - cf_export PROJECT_VERSION=$(mvn -Dmaven.repo.local=/codefresh/volume/${{CF_BRANCH_TAG_NORMALIZED}}/.m2/repository -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | tr '[:upper:]' '[:lower:]')
   check-copyright:
-    image: r.cfcr.io/openbanking/ob-release:latest
+    image: eu.gcr.io/openbanking-214714/ob-release:latest
     stage: "prepare"
     title: "Verify copyrights"
     working-directory: ${{main_clone}}
@@ -45,7 +45,7 @@ steps:
   build-stage:
     stage: "build"
     steps:
-    image: r.cfcr.io/openbanking/ob-release:latest
+    image: eu.gcr.io/openbanking-214714/ob-release:latest
     title: "Compile, build and install artifact"
     working-directory: ${{main_clone}}
     environment: *global_env
@@ -56,7 +56,7 @@ steps:
     stage: "unit-test"
     steps:
     # Unit-test stage
-    image: r.cfcr.io/openbanking/ob-release:latest
+    image: eu.gcr.io/openbanking-214714/ob-release:latest
     title: "Run unit tests"
     working-directory: ${{main_clone}}
     environment: *global_env
@@ -236,7 +236,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: r.cfcr.io/openbanking/ob-release:latest
+        image: eu.gcr.io/openbanking-214714/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-gateway/pom.xml
         # Simulate DNS routing multiple hostnames
@@ -263,7 +263,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: r.cfcr.io/openbanking/ob-release:latest
+        image: eu.gcr.io/openbanking-214714/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
         # Simulate DNS routing multiple hostnames
@@ -291,7 +291,7 @@ steps:
       scgw-tests:
         volumes:
           - ${{CF_VOLUME}}:/codefresh/volume
-        image: r.cfcr.io/openbanking/ob-release:latest
+        image: eu.gcr.io/openbanking-214714/ob-release:latest
         environment: *global_env
         command: /codefresh/volume/openbanking-reference-implementation/ci/run-it.sh ${{CF_BRANCH_TAG_NORMALIZED}} /codefresh/volume/openbanking-reference-implementation/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
         # Simulate DNS routing multiple hostnames

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: "2.0"
 
 stages:
   - prepare

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,4 +1,4 @@
-version: "2.0"
+version: "1.0"
 
 stages:
   - prepare
@@ -78,7 +78,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-docs-docker-image:
         type: build
         title: "Build docs service docker image"
@@ -89,7 +89,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-register-docker-image:
         type: build
         title: "Build register service docker image"
@@ -100,7 +100,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-directory-docker-image:
         type: build
         title: "Build directory service docker image"
@@ -111,7 +111,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-jwkms-image:
         type: build
         title: "Build jwkms service docker image"
@@ -122,7 +122,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-as-api-docker-image:
         type: build
         title: "Build as-api service docker image"
@@ -133,7 +133,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-rs-api-docker-image:
         type: build
         title: "Build rs-api service docker image"
@@ -144,7 +144,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-rs-rcs-docker-image:
         type: build
         title: "Build rs-rcs service docker image"
@@ -155,7 +155,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-rs-simulator-docker-image:
         type: build
         title: "Build rs-simulator service docker image"
@@ -166,7 +166,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
   docker-build-2:
     type: parallel
     stage: "docker-build"
@@ -181,7 +181,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-rs-ui-docker-image:
         type: build
         title: "Build rs-ui service docker image"
@@ -192,7 +192,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-admin-docker-image:
         type: build
         title: "Build admin service docker image"
@@ -203,7 +203,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-metrics-service-docker-image:
         type: build
         title: "Build metrics service docker image"
@@ -214,7 +214,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-monitoring-service-docker-image:
         type: build
         title: "Build monitoring service docker image"
@@ -225,7 +225,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
       build-scgw-docker-image:
         type: build
         title: "Build scgw service docker image"
@@ -236,7 +236,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-        registry: gcr
+
 
   integration-test-scgw:
     type: composition
@@ -344,105 +344,105 @@ steps:
         candidate: ${{build-config-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-docs-docker-image-latest:
         type: push
         title: "Push docs service docker image to registry"
         candidate: ${{build-docs-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-register-docker-image-latest:
         type: push
         title: "Push register service docker image to registry"
         candidate: ${{build-register-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-directory-docker-image-latest:
         type: push
         title: "Push directory service docker image to registry"
         candidate: ${{build-directory-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-jwkms-image-latest:
         type: push
         title: "Push jwkms service docker image to registry"
         candidate: ${{build-jwkms-image}}
         tags:
           - latest
-        registry: gcr
+
       push-as-api-docker-image-latest:
         type: push
         title: "Push as-api service docker image to registry"
         candidate: ${{build-as-api-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-rs-api-docker-image-latest:
         type: push
         title: "Push rs-api service docker image to registry"
         candidate: ${{build-rs-api-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-rs-rcs-docker-image-latest:
         type: push
         title: "Push rs-rcs service docker image to registry"
         candidate: ${{build-rs-rcs-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-rs-simulator-docker-image-latest:
         type: push
         title: "Push rs-simulator service docker image to registry"
         candidate: ${{build-rs-simulator-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-rs-store-docker-image-latest:
         type: push
         title: "Push rs-store service docker image to registry"
         candidate: ${{build-rs-store-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-rs-ui-docker-image-latest:
         type: push
         title: "Push rs-ui service docker image to registry"
         candidate: ${{build-rs-ui-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-admin-docker-image-latest:
         type: push
         title: "Push admin service docker image to registry"
         candidate: ${{build-admin-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-metrics-service-docker-image-latest:
         type: push
         title: "Push metrics service docker image to registry"
         candidate: ${{build-metrics-service-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-monitoring-service-docker-image-latest:
         type: push
         title: "Push monitoring service docker image to registry"
         candidate: ${{build-monitoring-service-docker-image}}
         tags:
           - latest
-        registry: gcr
+
       push-scgw-docker-image-latest:
         type: push
         title: "Push SCGW service docker image to registry"
         candidate: ${{build-scgw-docker-image}}
         tags:
           - latest
-        registry: gcr
+
     when:
       branch:
         only:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -78,6 +78,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-docs-docker-image:
         type: build
         title: "Build docs service docker image"
@@ -88,6 +89,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-register-docker-image:
         type: build
         title: "Build register service docker image"
@@ -98,6 +100,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-directory-docker-image:
         type: build
         title: "Build directory service docker image"
@@ -108,6 +111,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-jwkms-image:
         type: build
         title: "Build jwkms service docker image"
@@ -118,6 +122,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-as-api-docker-image:
         type: build
         title: "Build as-api service docker image"
@@ -128,6 +133,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-rs-api-docker-image:
         type: build
         title: "Build rs-api service docker image"
@@ -138,6 +144,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-rs-rcs-docker-image:
         type: build
         title: "Build rs-rcs service docker image"
@@ -148,6 +155,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-rs-simulator-docker-image:
         type: build
         title: "Build rs-simulator service docker image"
@@ -158,6 +166,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
   docker-build-2:
     type: parallel
     stage: "docker-build"
@@ -172,6 +181,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-rs-ui-docker-image:
         type: build
         title: "Build rs-ui service docker image"
@@ -182,6 +192,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-admin-docker-image:
         type: build
         title: "Build admin service docker image"
@@ -192,6 +203,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-metrics-service-docker-image:
         type: build
         title: "Build metrics service docker image"
@@ -202,6 +214,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-monitoring-service-docker-image:
         type: build
         title: "Build monitoring service docker image"
@@ -212,6 +225,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
       build-scgw-docker-image:
         type: build
         title: "Build scgw service docker image"
@@ -222,6 +236,7 @@ steps:
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
         tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        registry: gcr
 
   integration-test-scgw:
     type: composition

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -72,7 +72,7 @@ steps:
       build-config-docker-image:
         type: build
         title: "Build config service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/config
+        image_name: obri/config
         working-directory: ${{main_clone}}/forgerock-openbanking-config
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -83,7 +83,7 @@ steps:
       build-docs-docker-image:
         type: build
         title: "Build docs service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/docs
+        image_name: obri/docs
         working-directory: ${{main_clone}}/forgerock-openbanking-devportal/forgerock-openbanking-docs
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -94,7 +94,7 @@ steps:
       build-register-docker-image:
         type: build
         title: "Build register service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/register
+        image_name: obri/register
         working-directory: ${{main_clone}}/forgerock-openbanking-devportal/forgerock-openbanking-register
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -105,7 +105,7 @@ steps:
       build-directory-docker-image:
         type: build
         title: "Build directory service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/directory-services
+        image_name: obri/directory-services
         working-directory: ${{main_clone}}/forgerock-openbanking-directory-services
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -116,7 +116,7 @@ steps:
       build-jwkms-image:
         type: build
         title: "Build jwkms service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/jwkms
+        image_name: obri/jwkms
         working-directory: ${{main_clone}}/forgerock-openbanking-jwkms
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -127,7 +127,7 @@ steps:
       build-as-api-docker-image:
         type: build
         title: "Build as-api service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/as-api
+        image_name: obri/as-api
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -138,7 +138,7 @@ steps:
       build-rs-api-docker-image:
         type: build
         title: "Build rs-api service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-api
+        image_name: obri/rs-api
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -149,7 +149,7 @@ steps:
       build-rs-rcs-docker-image:
         type: build
         title: "Build rs-rcs service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-rcs
+        image_name: obri/rs-rcs
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -160,7 +160,7 @@ steps:
       build-rs-simulator-docker-image:
         type: build
         title: "Build rs-simulator service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-simulator
+        image_name: obri/rs-simulator
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -175,7 +175,7 @@ steps:
       build-rs-store-docker-image:
         type: build
         title: "Build rs-store service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-store
+        image_name: obri/rs-store
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -186,7 +186,7 @@ steps:
       build-rs-ui-docker-image:
         type: build
         title: "Build rs-ui service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/rs-ui
+        image_name: obri/rs-ui
         working-directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -197,7 +197,7 @@ steps:
       build-admin-docker-image:
         type: build
         title: "Build admin service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/admin
+        image_name: obri/admin
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-admin
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -208,7 +208,7 @@ steps:
       build-metrics-service-docker-image:
         type: build
         title: "Build metrics service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/metrics-service
+        image_name: obri/metrics-service
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -219,7 +219,7 @@ steps:
       build-monitoring-service-docker-image:
         type: build
         title: "Build monitoring service docker image"
-        image_name: ${{REGISTRY_CONTEXT}}/obri/monitoring
+        image_name: obri/monitoring
         working-directory: ${{main_clone}}/forgerock-openbanking-backstage/forgerock-openbanking-monitoring
         build_arguments:
           - JAR_FILE=target/forgerock-openbanking-*.jar
@@ -246,8 +246,8 @@ steps:
     description: "Start docker services via docker-compose and run scgw integration tests"
     composition: docker-compose.yml
     composition_variables:
-      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
-      - IMAGE=${{build-scgw-docker-image}}
+      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}} # deprecated
+      - CONFIG_IMAGE=${{build-config-docker-image}}
     working_directory: ${{main_clone}}/forgerock-openbanking-gateway
     composition_candidates:
       scgw-tests:
@@ -274,7 +274,8 @@ steps:
     description: "Start docker services via docker-compose and run rs-api integration tests"
     composition: docker-compose.yml
     composition_variables:
-      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}} # deprecated
+      - CONFIG_IMAGE=${{build-config-docker-image}}
     working_directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api
     composition_candidates:
       scgw-tests:
@@ -302,7 +303,8 @@ steps:
     description: "Start docker services via docker-compose and run rs-store integration tests"
     composition: docker-compose.yml
     composition_variables:
-      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+      - TAG=:${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}} # deprecated
+      - CONFIG_IMAGE=${{build-config-docker-image}}
     working_directory: ${{main_clone}}/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store
     composition_candidates:
       scgw-tests:

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -33,7 +33,7 @@ steps:
     environment: *global_env
     commands:
       - cf_export PROJECT_VERSION=$(mvn -Dmaven.repo.local=/codefresh/volume/${{CF_BRANCH_TAG_NORMALIZED}}/.m2/repository -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | tr '[:upper:]' '[:lower:]')
-      - cf_export REGISTRY_CONTEXT=${{REGISTRY_CONTEXT}}
+      - cf_export REGISTRY_CONTEXT=eu.gcr.io/openbanking-214714
   check-copyright:
     image: ${{REGISTRY_CONTEXT}}/ob-release:latest
     stage: "prepare"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       obref:
   config:
     container_name: config
-    image: r.cfcr.io/openbanking/obri/config
+    image: eu.gcr.io/openbanking-214714/obri/config
     ports:
       - "8888:8888"
     environment:
@@ -33,7 +33,7 @@ services:
       start_period: 40s
   jwkms:
     container_name: jwkms
-    image: r.cfcr.io/openbanking/obri/jwkms
+    image: eu.gcr.io/openbanking-214714/obri/jwkms
     ports:
       - "8097:8097"
       - "9097:9097"
@@ -57,7 +57,7 @@ services:
       start_period: 40s
   directory-services:
     container_name: directory-services
-    image: r.cfcr.io/openbanking/obri/directory-services
+    image: eu.gcr.io/openbanking-214714/obri/directory-services
     ports:
       - "8076:8076"
       - "9076:9076"
@@ -81,7 +81,7 @@ services:
       start_period: 40s
   scgw:
     container_name: scgw
-    image: r.cfcr.io/openbanking/obri/scgw
+    image: eu.gcr.io/openbanking-214714/obri/scgw
     ports:
       - "8074:8074"
       - "9074:9074"
@@ -118,7 +118,7 @@ services:
       start_period: 40s
   as-api:
     container_name: as-api
-    image: r.cfcr.io/openbanking/obri/as-api
+    image: eu.gcr.io/openbanking-214714/obri/as-api
     ports:
       - "8066:8066"
       - "9066:9066"
@@ -142,7 +142,7 @@ services:
       start_period: 40s
   rs-api:
     container_name: rs-api
-    image: r.cfcr.io/openbanking/obri/rs-api
+    image: eu.gcr.io/openbanking-214714/obri/rs-api
     ports:
       - "8094:8094"
       - "9094:9094"
@@ -166,7 +166,7 @@ services:
       start_period: 40s
   rs-rcs:
     container_name: rs-rcs
-    image: r.cfcr.io/openbanking/obri/rs-rcs
+    image: eu.gcr.io/openbanking-214714/obri/rs-rcs
     ports:
       - "8084:8084"
       - "9084:9084"
@@ -190,7 +190,7 @@ services:
       start_period: 40s
   rs-store:
     container_name: rs-store
-    image: r.cfcr.io/openbanking/obri/rs-store
+    image: eu.gcr.io/openbanking-214714/obri/rs-store
     ports:
       - "8086:8086"
       - "9086:9086"
@@ -214,7 +214,7 @@ services:
       start_period: 40s
   rs-ui:
     container_name: rs-ui
-    image: r.cfcr.io/openbanking/obri/rs-ui
+    image: eu.gcr.io/openbanking-214714/obri/rs-ui
     ports:
       - "8092:8092"
       - "9092:9092"
@@ -238,7 +238,7 @@ services:
       start_period: 40s
   monitoring:
     container_name: monitoring
-    image: r.cfcr.io/openbanking/obri/monitoring
+    image: eu.gcr.io/openbanking-214714/obri/monitoring
     ports:
       - "8073:8073"
       - "9073:9073"

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -98,7 +98,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/as-api</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/as-api</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/docker-compose.yml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/docker-compose.yml
@@ -2,7 +2,8 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking-214714/obri/config
+  # image: eu.gcr.io/openbanking-214714/obri/config
+  image: $CONFIG_IMAGE
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/docker-compose.yml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "18888:8888"
   environment:

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -157,7 +157,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-api</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-api</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -102,7 +102,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-rcs</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-rcs</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -102,7 +102,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/rs-simulator</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/rs-simulator</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/docker-compose.yml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: r.cfcr.io/openbanking/obri/config
+  image: eu.gcr.io/openbanking-214714/obri/config
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/docker-compose.yml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/docker-compose.yml
@@ -2,7 +2,8 @@ version: '2'
 services:
  config-rs-api:
   container_name: config-rs-api
-  image: eu.gcr.io/openbanking-214714/obri/config
+  # image: eu.gcr.io/openbanking-214714/obri/config
+  image: $CONFIG_IMAGE
   ports:
    - "28889:8888"
   environment:

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -170,7 +170,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/rs-store</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/rs-store</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/Dockerfile
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -98,7 +98,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/rs-ui</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/rs-ui</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/Dockerfile
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -103,7 +103,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/admin</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/admin</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/Dockerfile
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -102,7 +102,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/metrics</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/metrics</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/Dockerfile
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -178,7 +178,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/monitoring</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/monitoring</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-config/Dockerfile
+++ b/forgerock-openbanking-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -96,7 +96,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/config</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/config</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/Dockerfile
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -169,7 +169,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/docs</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/docs</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/Dockerfile
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -102,7 +102,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/register</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/register</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-directory-services/Dockerfile
+++ b/forgerock-openbanking-directory-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -93,7 +93,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/directory-services</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/directory-services</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-gateway/Dockerfile
+++ b/forgerock-openbanking-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-gateway/docker-compose.yml
+++ b/forgerock-openbanking-gateway/docker-compose.yml
@@ -2,7 +2,8 @@ version: '2'
 services:
  config-rs-rcs:
   container_name: config-scgw
-  image: eu.gcr.io/openbanking-214714/obri/config$TAG
+  # image: eu.gcr.io/openbanking-214714/obri/config$TAG
+  image: $IMAGE
   ports:
    - "18887:8888"
   environment:

--- a/forgerock-openbanking-gateway/docker-compose.yml
+++ b/forgerock-openbanking-gateway/docker-compose.yml
@@ -3,7 +3,7 @@ services:
  config-rs-rcs:
   container_name: config-scgw
   # image: eu.gcr.io/openbanking-214714/obri/config$TAG
-  image: $IMAGE
+  image: $CONFIG_IMAGE
   ports:
    - "18887:8888"
   environment:

--- a/forgerock-openbanking-gateway/docker-compose.yml
+++ b/forgerock-openbanking-gateway/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
  config-rs-rcs:
   container_name: config-scgw
-  image: r.cfcr.io/openbanking/obri/config$TAG
+  image: eu.gcr.io/openbanking-214714/obri/config$TAG
   ports:
    - "18887:8888"
   environment:

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -164,7 +164,7 @@
 				<artifactId>dockerfile-maven-plugin</artifactId>
 				<configuration>
 					<skipPush>false</skipPush>
-					<repository>r.cfcr.io/openbanking/obri/scgw</repository>
+					<repository>eu.gcr.io/openbanking-214714/obri/scgw</repository>
 					<buildArgs>
 						<JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
 					</buildArgs>

--- a/forgerock-openbanking-jwkms/Dockerfile
+++ b/forgerock-openbanking-jwkms/Dockerfile
@@ -1,4 +1,4 @@
-FROM r.cfcr.io/openbanking/obri/basems
+FROM eu.gcr.io/openbanking-214714/obri/basems
 
 ARG JAR_FILE
 ARG VERSION_FILE

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -98,7 +98,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                  <configuration>
                     <skipPush>false</skipPush>
-                    <repository>r.cfcr.io/openbanking/obri/jwkms</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/jwkms</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>


### PR DESCRIPTION
Reference images in GCR instead of CFCR. GCR has been manually pre-seeded with `latest` tag of each image.

Part of ForgeCloud/ob-deploy#468