### PR TITLE
Fix issue 1876 - Not able to fetch user data of a PSU from forgeRock

### DIFF
--- a/.idea/runConfigurations/rs_ui_remote.xml
+++ b/.idea/runConfigurations/rs_ui_remote.xml
@@ -4,8 +4,12 @@
     <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />
     <option name="HOST" value="localhost" />
-    <option name="PORT" value="8092" />
+    <option name="PORT" value="9092" />
     <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="9092" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>


### PR DESCRIPTION
**Describe the bug**
Not able to fetch user data of a PSU from forgeRock
https://github.com/ForgeCloud/ob-reference-implementation/issues/1876

**Expected behaviour**
The data related with the user authenticated by user session.

**Release Notes**
Cookie collector implemented in the authorisation adapter sequence.

**Affected App**: RS-UI

Description: X