### PR TITLE
Tag images master branch

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -78,7 +78,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-docs-docker-image:
         type: build
@@ -89,7 +91,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-register-docker-image:
         type: build
@@ -100,7 +104,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-directory-docker-image:
         type: build
@@ -111,7 +117,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-jwkms-image:
         type: build
@@ -122,7 +130,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-as-api-docker-image:
         type: build
@@ -133,7 +143,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-rs-api-docker-image:
         type: build
@@ -144,7 +156,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-rs-rcs-docker-image:
         type: build
@@ -155,7 +169,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-rs-simulator-docker-image:
         type: build
@@ -166,7 +182,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
   docker-build-2:
     type: parallel
@@ -181,7 +199,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-rs-ui-docker-image:
         type: build
@@ -192,7 +212,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-admin-docker-image:
         type: build
@@ -203,7 +225,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-metrics-service-docker-image:
         type: build
@@ -214,7 +238,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-monitoring-service-docker-image:
         type: build
@@ -225,7 +251,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
       build-scgw-docker-image:
         type: build
@@ -236,7 +264,9 @@ steps:
           - JAR_FILE=target/forgerock-openbanking-*.jar
           - VERSION_FILE=target/VERSION
           - SERVICE_FILE=target/SERVICE
-        tag: ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
+        tags:
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         disable_push: true
 
   integration-test-scgw:
@@ -348,6 +378,8 @@ steps:
         candidate: ${{build-config-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-docs-docker-image-latest:
         type: push
@@ -355,6 +387,8 @@ steps:
         candidate: ${{build-docs-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-register-docker-image-latest:
         type: push
@@ -362,6 +396,8 @@ steps:
         candidate: ${{build-register-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-directory-docker-image-latest:
         type: push
@@ -369,6 +405,8 @@ steps:
         candidate: ${{build-directory-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-jwkms-image-latest:
         type: push
@@ -376,6 +414,8 @@ steps:
         candidate: ${{build-jwkms-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-as-api-docker-image-latest:
         type: push
@@ -383,6 +423,8 @@ steps:
         candidate: ${{build-as-api-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-api-docker-image-latest:
         type: push
@@ -390,6 +432,8 @@ steps:
         candidate: ${{build-rs-api-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-rcs-docker-image-latest:
         type: push
@@ -397,6 +441,8 @@ steps:
         candidate: ${{build-rs-rcs-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-simulator-docker-image-latest:
         type: push
@@ -404,6 +450,8 @@ steps:
         candidate: ${{build-rs-simulator-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-store-docker-image-latest:
         type: push
@@ -411,6 +459,8 @@ steps:
         candidate: ${{build-rs-store-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-ui-docker-image-latest:
         type: push
@@ -418,6 +468,8 @@ steps:
         candidate: ${{build-rs-ui-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-admin-docker-image-latest:
         type: push
@@ -425,6 +477,8 @@ steps:
         candidate: ${{build-admin-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-metrics-service-docker-image-latest:
         type: push
@@ -432,6 +486,8 @@ steps:
         candidate: ${{build-metrics-service-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-monitoring-service-docker-image-latest:
         type: push
@@ -439,6 +495,8 @@ steps:
         candidate: ${{build-monitoring-service-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
       push-scgw-docker-image-latest:
         type: push
@@ -446,6 +504,8 @@ steps:
         candidate: ${{build-scgw-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}
+          - ${{CF_SHORT_REVISION}}
         registry: gcr
     when:
       branch:
@@ -495,12 +555,12 @@ steps:
     fail_fast: false
     commands:
       - apt update && apt install jq
-      - jq -M  '[ .[] | if (.helmReference  | contains("obri-helm-charts/spring-application")) then .version |= "'${PROJECT_VERSION}-${CF_SHORT_REVISION}'" else . end ]' client_releases/master-dev/releases.json > client_releases/master-dev/releases.json.tmp
+      - jq -M  '[ .[] | if (.helmReference  | contains("obri-helm-charts/spring-application")) then .version |= "'${PROJECT_VERSION}'" else . end ]' client_releases/master-dev/releases.json > client_releases/master-dev/releases.json.tmp
       - mv client_releases/master-dev/releases.json.tmp client_releases/master-dev/releases.json
       - git config --global user.email "codefresh@codefresh.io"
       - git config --global user.name "Codefresh"
       - git add client_releases/master-dev/releases.json
-      - git commit --allow-empty -m "Bumping master-dev to deploy spring apps with version ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}"
+      - git commit --allow-empty -m "Bumping master-dev to deploy spring apps with version ${{PROJECT_VERSION}}"
       - git push https://${{GITHUB_USERNAME}}:${{GITHUB_ACCESS_TOKEN}}@github.com/ForgeCloud/ob-deploy.git "master"
     when:
       branch:


### PR DESCRIPTION
## Description
We need to tag the images with the pom version also, and the commit hash to help find the images on the registry, until now the images builded were tagged "latest" only. We need more tags for these images on the registry.

## Impacted Areas in Application
Deployment method.