### PR TITLE
Tag pushed docker images with ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -348,6 +348,7 @@ steps:
         candidate: ${{build-config-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-docs-docker-image-latest:
         type: push
@@ -355,6 +356,7 @@ steps:
         candidate: ${{build-docs-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-register-docker-image-latest:
         type: push
@@ -362,6 +364,7 @@ steps:
         candidate: ${{build-register-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-directory-docker-image-latest:
         type: push
@@ -369,6 +372,7 @@ steps:
         candidate: ${{build-directory-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-jwkms-image-latest:
         type: push
@@ -376,6 +380,7 @@ steps:
         candidate: ${{build-jwkms-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-as-api-docker-image-latest:
         type: push
@@ -383,6 +388,7 @@ steps:
         candidate: ${{build-as-api-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-api-docker-image-latest:
         type: push
@@ -390,6 +396,7 @@ steps:
         candidate: ${{build-rs-api-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-rcs-docker-image-latest:
         type: push
@@ -397,6 +404,7 @@ steps:
         candidate: ${{build-rs-rcs-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-simulator-docker-image-latest:
         type: push
@@ -404,6 +412,7 @@ steps:
         candidate: ${{build-rs-simulator-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-store-docker-image-latest:
         type: push
@@ -411,6 +420,7 @@ steps:
         candidate: ${{build-rs-store-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-rs-ui-docker-image-latest:
         type: push
@@ -418,6 +428,7 @@ steps:
         candidate: ${{build-rs-ui-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-admin-docker-image-latest:
         type: push
@@ -425,6 +436,7 @@ steps:
         candidate: ${{build-admin-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-metrics-service-docker-image-latest:
         type: push
@@ -432,6 +444,7 @@ steps:
         candidate: ${{build-metrics-service-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-monitoring-service-docker-image-latest:
         type: push
@@ -439,6 +452,7 @@ steps:
         candidate: ${{build-monitoring-service-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
       push-scgw-docker-image-latest:
         type: push
@@ -446,6 +460,7 @@ steps:
         candidate: ${{build-scgw-docker-image}}
         tags:
           - latest
+          - ${{PROJECT_VERSION}}-${{CF_SHORT_REVISION}}
         registry: gcr
     when:
       branch:


### PR DESCRIPTION
- or deploys for anything other than latest doesn't work

## Description
This is because after deploying to lbg-dev images weren't found. Looking in gcr the last run of the pipeline only tagged images with `latest`

