### PR TITLE
Make OBRisk1.PaymentContextCode field configurably a required field

### DIFF
--- a/forgerock-openbanking-gateway/src/main/resources/filtered/logback-spring.xml
+++ b/forgerock-openbanking-gateway/src/main/resources/filtered/logback-spring.xml
@@ -19,7 +19,7 @@
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
     <logger name="com.forgerock" level="DEBUG"/>
-    <logger name="org.springframework" level="INFO"/>
+    <logger name="org.springframework" level="TRACE"/>
     <logger name="org.forgerock.openbanking.commons.auth" level="TRACE"/>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <ob-auth.version>1.0.57</ob-auth.version>
         <ob-directory.version>1.4.73</ob-directory.version>
         <ob-auth.version>1.0.57</ob-auth.version>
-        <ob-aspsp.version>1.0.82</ob-aspsp.version>
+        <ob-aspsp.version>1.0.83</ob-aspsp.version>
         <ob-clients.version>1.0.34</ob-clients.version>
         <ob-extensions.version>1.0.8</ob-extensions.version>
     </properties>


### PR DESCRIPTION
Part fix for #196

Some implementors have expressed a need to be able to enfore that a
PaymentCodeContext is provided in the Risk object when requesting a
consent. This PR enables this feature to be turned on by setting the
following spring config setting to true;
rs.api.payment.validate.risk.require-payment-context-code

This change is included in v1.0.83 of openbanking-aspsp

