### PR TITLE
Fix/ui e2e test analytics auth issue 243

### DIFF
--- a/.idea/runConfigurations/metrics-service_remote.xml
+++ b/.idea/runConfigurations/metrics-service_remote.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="metrics-service remote" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="9098" />
+    <option name="AUTO_RESTART" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     container_name: mongo-mongodb
     image: mongo
     ports:
-    - "27017:27017"
+      - "27017:27017"
     volumes:
-    - ./mongo/:/docker-entrypoint-initdb.d/:ro
-    - $PWD/mongodata:/data/db  # Persist mongo data to $HOME/mongo
+      - ./mongo/:/docker-entrypoint-initdb.d/:ro
+      - $PWD/mongodata:/data/db  # Persist mongo data to $HOME/mongo
     hostname: mongo-mongodb
     networks:
       obref:
@@ -124,7 +124,8 @@ services:
       - ./forgerock-openbanking-gateway/src/main/resources/unfiltered/keystore/truststore.jks:/etc/ssl/certs/java/cacerts
     networks:
       obref:
-        aliases: 
+        aliases:
+          - service.metrics.dev-ob.forgerock.financial
           - service.directory.dev-ob.forgerock.financial
           - am.dev-ob.forgerock.financial
           - as.aspsp.dev-ob.forgerock.financial
@@ -295,6 +296,31 @@ services:
       retries: 3
       start_period: 40s
 
+  metrics-service:
+    container_name: metrics-services
+    image: eu.gcr.io/openbanking-214714/obri/metrics-service
+    ports:
+      - "8098:8098"
+      - "9098:9098"
+    environment:
+      SPRING_CLOUD_CONFIG_URI: http://config.dev-ob.forgerock.financial:8888
+      SPRING_PROFILES_ACTIVE: native,console-logging
+      java_opts: -Xmx256m -XX:+UseConcMarkSweepGC -Dserver.port=8098 -Dam.internal-port=8443
+      HOSTNAME: metrics-services
+      CONSOLE_LOG_PATTERN: "%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr([%X{traceId}]){green} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}"
+      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:9098,server=y,suspend=n
+    volumes:
+      - ./forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/src/main/resources/unfiltered/keystore/keystore.jks:/opt/ob/config/keystore.jks:ro
+      - ./forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/src/main/resources/unfiltered/keystore/truststore.jks:/etc/ssl/certs/java/cacerts
+    networks:
+      obref:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-k", "https://localhost:8098/actuator/health"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
   openam:
     build:
       context: .
@@ -308,7 +334,8 @@ services:
       obref:
 
   auth-ui:
-    image: openbankingtoolkit/openbanking-auth-ui
+    image: eu.gcr.io/openbanking-214714/obri/auth
+    container_name: auth-ui
     ports:
       - "4203:443"
     environment:
@@ -321,7 +348,8 @@ services:
       - ./keystore/ui/dev-ob.forgerock.financial.conf:/etc/nginx/conf.d/default.conf
 
   directory-ui:
-    image: openbankingtoolkit/openbanking-directory-ui
+    image: eu.gcr.io/openbanking-214714/obri/directory-ui
+    container_name: directory-ui
     ports:
       - "4202:443"
     environment:
@@ -335,7 +363,8 @@ services:
       - ./keystore/ui/dev-ob.forgerock.financial.conf:/etc/nginx/conf.d/default.conf
 
   bank-ui:
-    image: openbankingtoolkit/openbanking-bank-ui
+    image: eu.gcr.io/openbanking-214714/obri/bank-ui
+    container_name: bank-ui
     ports:
       - "4201:443"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,7 +334,7 @@ services:
       obref:
 
   auth-ui:
-    image: eu.gcr.io/openbanking-214714/obri/auth
+    image: eu.gcr.io/openbanking-214714/obri/auth-ui
     container_name: auth-ui
     ports:
       - "4203:443"

--- a/forgerock-am/amster/config/realms/root-auth/UserSelfService.json
+++ b/forgerock-am/amster/config/realms/root-auth/UserSelfService.json
@@ -46,7 +46,7 @@
       "userRegistrationTokenTTL" : 300,
       "userRegistrationEmailSubject" : [ "en|Registration email" ],
       "userRegistrationCaptchaEnabled" : false,
-      "userRegistrationValidUserAttributes" : [ "userPassword", "mail", "givenName", "kbaInfo", "inetUserStatus", "sn", "username" ]
+      "userRegistrationValidUserAttributes" : [ "userPassword", "mail", "givenName", "kbaInfo", "inetUserStatus", "sn", "username", "sunIdentityMSISDNNumber" ]
     },
     "generalConfig" : {
       "minimumAnswersToDefine" : 1,

--- a/forgerock-am/amster/config/realms/root-openbanking/UserSelfService.json
+++ b/forgerock-am/amster/config/realms/root-openbanking/UserSelfService.json
@@ -46,7 +46,7 @@
       "userRegistrationTokenTTL" : 300,
       "userRegistrationEmailSubject" : [ "en|Registration email" ],
       "userRegistrationCaptchaEnabled" : false,
-      "userRegistrationValidUserAttributes" : [ "userPassword", "mail", "givenName", "kbaInfo", "inetUserStatus", "sn", "username" ]
+      "userRegistrationValidUserAttributes" : [ "userPassword", "mail", "givenName", "kbaInfo", "inetUserStatus", "sn", "username", "sunIdentityMSISDNNumber" ]
     },
     "generalConfig" : {
       "minimumAnswersToDefine" : 1,

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -43,10 +43,6 @@
             <groupId>com.forgerock.openbanking.common</groupId>
             <artifactId>forgerock-openbanking-common</artifactId>
         </dependency>
-<!--        <dependency>
-            <groupId>com.forgerock.openbanking</groupId>
-            <artifactId>forgerock-openbanking-upgrade</artifactId>
-        </dependency>-->
         <dependency>
             <groupId>com.forgerock.openbanking.analytics</groupId>
             <artifactId>forgerock-openbanking-analytics-core</artifactId>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -43,6 +43,10 @@
             <groupId>com.forgerock.openbanking.common</groupId>
             <artifactId>forgerock-openbanking-common</artifactId>
         </dependency>
+<!--        <dependency>
+            <groupId>com.forgerock.openbanking</groupId>
+            <artifactId>forgerock-openbanking-upgrade</artifactId>
+        </dependency>-->
         <dependency>
             <groupId>com.forgerock.openbanking.analytics</groupId>
             <artifactId>forgerock-openbanking-analytics-core</artifactId>
@@ -106,7 +110,7 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <skipPush>false</skipPush>
-                    <repository>eu.gcr.io/openbanking-214714/obri/metrics</repository>
+                    <repository>eu.gcr.io/openbanking-214714/obri/metrics-service</repository>
                     <buildArgs>
                         <JAR_FILE>target/${project.build.finalName}.jar</JAR_FILE>
                     </buildArgs>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/src/main/java/com/forgerock/openbanking/analytics/ForgerockOpenbankingMetricsServicesApplication.java
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/src/main/java/com/forgerock/openbanking/analytics/ForgerockOpenbankingMetricsServicesApplication.java
@@ -30,11 +30,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication(scanBasePackages = "com.forgerock.openbanking")
+@EnableMongoRepositories(basePackages = "com.forgerock.openbanking")
 @EnableSwagger2
 @EnableDiscoveryClient
 @EnableScheduling
 @EnableWebSecurity
-@EnableMongoRepositories
 @Import(MetricsApplicationSecurityConfiguration.class)
 public class ForgerockOpenbankingMetricsServicesApplication {
 

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/src/main/java/com/forgerock/openbanking/monitoring/api/test/UserForTestApiController.java
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/src/main/java/com/forgerock/openbanking/monitoring/api/test/UserForTestApiController.java
@@ -35,6 +35,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 @Controller
@@ -44,12 +45,18 @@ public class UserForTestApiController implements UserForTestApi {
     private static final String USER_PREFIX = "test_";
     private static final String USER_DEFAULT_PASSWORD = "changeit";
 
+    private final AMASPSPGateway amGateway;
+
+    private final AMOpenBankingConfiguration amOpenBankingConfiguration;
+
+    private final AMAuthentication amAuthentication;
+
     @Autowired
-    private AMASPSPGateway amGateway;
-    @Autowired
-    private AMOpenBankingConfiguration amOpenBankingConfiguration;
-    @Autowired
-    private AMAuthentication amAuthentication;
+    public UserForTestApiController(AMASPSPGateway amGateway, AMOpenBankingConfiguration amOpenBankingConfiguration, AMAuthentication amAuthentication) {
+        this.amGateway = amGateway;
+        this.amOpenBankingConfiguration = amOpenBankingConfiguration;
+        this.amAuthentication = amAuthentication;
+    }
 
     @Override
     public ResponseEntity createUser() throws OBErrorResponseException {
@@ -60,6 +67,11 @@ public class UserForTestApiController implements UserForTestApi {
                         .user(UserRegistrationRequest.User.builder()
                                 .username(USER_PREFIX + UUID.randomUUID())
                                 .userPassword(USER_DEFAULT_PASSWORD)
+                                .sunIdentityMSISDNNumber(
+                                        Arrays.asList(
+                                                UserRegistrationRequest.AnalyticsAuthority.PUSH_KPI.getAuthority(),
+                                                UserRegistrationRequest.AnalyticsAuthority.READ_KPI.getAuthority())
+                                )
                                 .build())
                         .build())
                 .build();

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/src/main/java/com/forgerock/openbanking/monitoring/model/user/UserRegistrationRequest.java
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/src/main/java/com/forgerock/openbanking/monitoring/model/user/UserRegistrationRequest.java
@@ -23,6 +23,8 @@ package com.forgerock.openbanking.monitoring.model.user;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @Builder
 public class UserRegistrationRequest {
@@ -40,5 +42,34 @@ public class UserRegistrationRequest {
     public static class User {
         private String username;
         private String userPassword;
+        private List<String> sunIdentityMSISDNNumber;
+    }
+
+    /**
+     * Authorities to access analytics @see <a href="https://github.com/OpenBankingToolkit/openbanking-toolkit/wiki/analytics" />
+     */
+    public enum AnalyticsAuthority {
+        PUSH_KPI("PUSH_KPI"),
+
+        READ_KPI("READ_KPI");
+
+        private final String authority;
+
+        AnalyticsAuthority(String authority) {
+            this.authority = authority;
+        }
+
+        public String getAuthority() {
+            return authority;
+        }
+
+        public static AnalyticsAuthority fromAuthority(String authority) {
+            for(AnalyticsAuthority analyticsAuthority: AnalyticsAuthority.values()) {
+                if (analyticsAuthority.authority.equals(authority)) {
+                    return analyticsAuthority;
+                }
+            }
+            throw new UnsupportedOperationException("Unsupported analytics authority: '" + authority + "'");
+        }
     }
 }

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application-native.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application-native.yml
@@ -135,6 +135,12 @@ spring:
   data:
     mongodb:
       uri: mongodb://mongo:cj9ka0f6ie1mq1akqsb1iy10wp1yfz5b@mongo-mongodb/mongo
+  #Disable zipkin on local for native profile
+  zipkin:
+    enabled: false
+  sleuth:
+    opentracing:
+      enabled: false
 
 #Authentication
 jwt-auth:

--- a/pom.xml
+++ b/pom.xml
@@ -45,13 +45,13 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-analytics.version>1.1.49-SNAPSHOT</ob-analytics.version>
-        <ob-jwkms.version>1.1.70-SNAPSHOT</ob-jwkms.version>
+        <ob-analytics.version>1.1.49</ob-analytics.version>
+        <ob-jwkms.version>1.1.70</ob-jwkms.version>
         <ob-auth.version>1.0.57</ob-auth.version>
         <ob-directory.version>1.4.73</ob-directory.version>
         <ob-auth.version>1.0.57</ob-auth.version>
         <ob-aspsp.version>1.0.86</ob-aspsp.version>
-        <ob-clients.version>1.0.34</ob-clients.version>
+        <ob-clients.version>1.0.35</ob-clients.version>
         <ob-extensions.version>1.0.10</ob-extensions.version>
     </properties>
 
@@ -74,11 +74,6 @@
                 <artifactId>forgerock-openbanking-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!--<dependency>
-                <groupId>com.forgerock.openbanking</groupId>
-                <artifactId>forgerock-openbanking-upgrade</artifactId>
-                <version>1.0.77-SNAPSHOT</version>
-            </dependency>-->
             <dependency>
                 <groupId>com.forgerock.openbanking.analytics</groupId>
                 <artifactId>forgerock-openbanking-analytics-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-analytics.version>1.1.48</ob-analytics.version>
-        <ob-jwkms.version>1.1.67</ob-jwkms.version>
+        <ob-analytics.version>1.1.49-SNAPSHOT</ob-analytics.version>
+        <ob-jwkms.version>1.1.70-SNAPSHOT</ob-jwkms.version>
         <ob-auth.version>1.0.57</ob-auth.version>
         <ob-directory.version>1.4.73</ob-directory.version>
         <ob-auth.version>1.0.57</ob-auth.version>
@@ -74,6 +74,11 @@
                 <artifactId>forgerock-openbanking-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <!--<dependency>
+                <groupId>com.forgerock.openbanking</groupId>
+                <artifactId>forgerock-openbanking-upgrade</artifactId>
+                <version>1.0.77-SNAPSHOT</version>
+            </dependency>-->
             <dependency>
                 <groupId>com.forgerock.openbanking.analytics</groupId>
                 <artifactId>forgerock-openbanking-analytics-core</artifactId>


### PR DESCRIPTION
## Description
Metrics-services added to docker-compose
Disabled zipkin on native profile to avoid exceptions in local envs.
AM config: `sunIdentityMSISDNNumber` attribute added to enable add the authorities in the register for testing purpose.

## Issues related
Resolve #243 
Resolve #253 

## Impacted Areas in Application
* Metrics-services
* Analytics (authorities for e2e UI testing)


