### PR TITLE
bumped the latest version of openbanking libraries and starter parent

### DIFF
--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -137,7 +137,6 @@
         <dependency>
             <groupId>com.forgerock.openbanking</groupId>
             <artifactId>forgerock-openbanking-auth</artifactId>
-            <version>${ob-auth.version}</version>
         </dependency>
         <dependency>
             <groupId>com.forgerock.openbanking.clients</groupId>

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -82,7 +82,6 @@ rs-discovery:
   hostname: matls.rs.aspsp.${dns.hosts.root}
   base-url: https://${rs-discovery.hostname}
   apis:
-    version: ""
     payments:
       v_1_1:
         createSingleImmediatePayment: ${rs-discovery.base-url}/open-banking/v1.1/payments

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.74</version>
+        <version>1.0.75</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -45,14 +45,13 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-analytics.version>1.1.49</ob-analytics.version>
-        <ob-jwkms.version>1.1.70</ob-jwkms.version>
-        <ob-auth.version>1.0.58</ob-auth.version>
-        <ob-directory.version>1.4.73</ob-directory.version>
-        <ob-auth.version>1.0.57</ob-auth.version>
-        <ob-aspsp.version>1.0.90</ob-aspsp.version>
-        <ob-clients.version>1.0.35</ob-clients.version>
-        <ob-extensions.version>1.0.11</ob-extensions.version>
+        <ob-analytics.version>1.1.50</ob-analytics.version>
+        <ob-jwkms.version>1.1.71</ob-jwkms.version>
+        <ob-auth.version>1.0.59</ob-auth.version>
+        <ob-directory.version>1.4.74</ob-directory.version>
+        <ob-aspsp.version>1.0.91</ob-aspsp.version>
+        <ob-clients.version>1.0.36</ob-clients.version>
+        <ob-extensions.version>1.0.12</ob-extensions.version>
     </properties>
 
     <modules>
@@ -143,6 +142,11 @@
                 <groupId>com.forgerock.openbanking.aspsp</groupId>
                 <artifactId>forgerock-openbanking-uk-aspsp-rs-rcs-server</artifactId>
                 <version>${ob-aspsp.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.forgerock.openbanking</groupId>
+                <artifactId>forgerock-openbanking-auth</artifactId>
+                <version>${ob-auth.version}</version>
             </dependency>
             <!-- openbanking extensions -->
             <dependency>


### PR DESCRIPTION
## Description
- Deleted the key apis:version: "" on [application.yml file](https://github.com/OpenBankingToolkit/openbanking-reference-implementation/blob/master/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml)

Populate the latest versions of Open Banking libraries:
- [uk extensions](https://github.com/OpenBankingToolkit/openbanking-uk-extensions) 1.0.12
- [starter parent](https://github.com/OpenBankingToolkit/openbanking-parent) 1.0.75
- [aspsp](https://github.com/OpenBankingToolkit/openbanking-aspsp) 1.0.91
- [directory](https://github.com/OpenBankingToolkit/openbanking-directory) 1.4.74
- [analytics](https://github.com/OpenBankingToolkit/openbanking-analytics) 1.1.50
- [auth](https://github.com/OpenBankingToolkit/openbanking-auth) 1.0.59
- [clients](https://github.com/OpenBankingToolkit/openbanking-clients) 1.0.36
- [jwkms](https://github.com/OpenBankingToolkit/openbanking-jwkms) 1.1.71

> prepare for next release.

## Resolves
Closes https://github.com/OpenBankingToolkit/openbanking-analytics/issues/163

