### PR TITLE
Required changes to support v3.1.5 of the payments API (#272)

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidationService;
 import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -62,6 +62,7 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collections;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRFileConsentConverter.toFRFileConsent2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
@@ -143,12 +144,12 @@ public class CSVFilePaymentConsentsApiController {
     ) throws OBErrorResponseException {
         log.trace("CVS controller.");
         log.trace("Received '{}'.", fileParam);
-        FRFileConsent2 consent = filePaymentService.getPayment(consentId);
+        FRFileConsent5 consent = filePaymentService.getPayment(consentId);
         try {
             CSVParser parser = CSVParserFactory.parse(CSVFilePaymentType.fromStringType(consent.getFileType().getFileType()), fileParam);
             CSVFilePayment filePayment = parser.parse().getCsvFilePayment();
-            CSVValidationService.Consent.numTransactions(consent, filePayment);
-            CSVValidationService.Consent.controlSum(consent, filePayment);
+            CSVValidationService.Consent.numTransactions(toFRFileConsent2(consent), filePayment);
+            CSVValidationService.Consent.controlSum(toFRFileConsent2(consent), filePayment);
         } catch (OBErrorException | CSVErrorException e) {
             if (e instanceof CSVErrorException) {
                 throw new OBErrorResponseException(((CSVErrorException) e).getCsvErrorType().getHttpStatus(), OBRIErrorResponseCategory.REQUEST_INVALID, "csv error", ((CSVErrorException) e).getOBError());

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidationService;
 import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -63,11 +63,12 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collections;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRFileConsentConverter.toFRFileConsent2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
 @Controller("CSVFilePaymentConsentsApiV3.1.3")
-@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp"})
+@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp"})
 @Slf4j
 public class CSVFilePaymentConsentsApiController {
 
@@ -142,12 +143,12 @@ public class CSVFilePaymentConsentsApiController {
     ) throws OBErrorResponseException {
         log.trace("CVS controller.");
         log.trace("Received '{}'.", fileParam);
-        FRFileConsent2 consent = filePaymentService.getPayment(consentId);
+        FRFileConsent5 consent = filePaymentService.getPayment(consentId);
         try {
             CSVParser parser = CSVParserFactory.parse(CSVFilePaymentType.fromStringType(consent.getFileType().getFileType()), fileParam);
             CSVFilePayment filePayment = parser.parse().getCsvFilePayment();
-            CSVValidationService.Consent.numTransactions(consent, filePayment);
-            CSVValidationService.Consent.controlSum(consent, filePayment);
+            CSVValidationService.Consent.numTransactions(toFRFileConsent2(consent), filePayment);
+            CSVValidationService.Consent.controlSum(toFRFileConsent2(consent), filePayment);
         } catch (OBErrorException | CSVErrorException e) {
             if (e instanceof CSVErrorException) {
                 throw new OBErrorResponseException(((CSVErrorException) e).getCsvErrorType().getHttpStatus(), OBRIErrorResponseCategory.REQUEST_INVALID, "csv error", ((CSVErrorException) e).getOBError());

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_2/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_2/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -31,7 +31,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHead
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.constants.OIDCConstants;
@@ -65,7 +65,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.org.openbanking.OBHeaders;
 import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -152,9 +152,9 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
         String fileConsentId = UUID.randomUUID().toString();
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -191,9 +191,9 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
         String fileConsentId = UUID.randomUUID().toString();
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -222,8 +222,8 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param fileType
      * @return
      */
-    private static final OBWriteFileConsent2 mockConsent(String csvFileContent, String fileType){
-        OBWriteFileConsent2 consentRequest = JMockData.mock(OBWriteFileConsent2.class);
+    private static final OBWriteFileConsent3 mockConsent(String csvFileContent, String fileType){
+        OBWriteFileConsent3 consentRequest = JMockData.mock(OBWriteFileConsent3.class);
         consentRequest.getData().getInitiation().fileHash(computeSHA256FullHash(csvFileContent));
         consentRequest.getData().getInitiation().fileReference("FileRef001");
         consentRequest.getData().getInitiation().fileType(fileType);
@@ -241,14 +241,14 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param consentRequest
      * @return
      */
-    private static final FRFileConsent2 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent2 consentRequest){
-        FRFileConsent2 frFileConsent2 = JMockData.mock(FRFileConsent2.class);
-        frFileConsent2.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
-        frFileConsent2.setId(fileConsentId);
-        frFileConsent2.setFileContent(csvFileContent);
-        frFileConsent2.setPayments(Collections.emptyList());
-        frFileConsent2.setWriteFileConsent(consentRequest);
-        return frFileConsent2;
+    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent5 frFileConsent5 = JMockData.mock(FRFileConsent5.class);
+        frFileConsent5.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent5.setId(fileConsentId);
+        frFileConsent5.setFileContent(csvFileContent);
+        frFileConsent5.setPayments(Collections.emptyList());
+        frFileConsent5.setWriteFileConsent(consentRequest);
+        return frFileConsent5;
     }
 
     /**

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_5/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_5/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.test.v3_1_4;
+package com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.test.v3_1_5;
 
 import com.forgerock.openbanking.am.services.AMResourceServerService;
 import com.forgerock.openbanking.aspsp.rs.ForgerockOpenbankingRsApiApplication;
@@ -31,7 +31,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHead
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.constants.OIDCConstants;
@@ -65,7 +65,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.org.openbanking.OBHeaders;
 import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -95,7 +95,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {ForgerockOpenbankingRsApiApplication.class})
 public class CSVFilePaymentConsentsRsApiControllerIT {
 
-    private final static String _url = "/open-banking/v3.1.4/pisp/file-payment-consents/{ConsentId}/file";
+    private final static String _url = "/open-banking/v3.1.5/pisp/file-payment-consents/{ConsentId}/file";
     private CSVFilePayment file;
 
     private MockMvc mockMvc;
@@ -152,9 +152,9 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
         String fileConsentId = UUID.randomUUID().toString();
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -190,9 +190,9 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
         given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
         String fileConsentId = UUID.randomUUID().toString();
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -220,8 +220,8 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param fileType
      * @return
      */
-    private static final OBWriteFileConsent2 mockConsent(String csvFileContent, String fileType){
-        OBWriteFileConsent2 consentRequest = JMockData.mock(OBWriteFileConsent2.class);
+    private static final OBWriteFileConsent3 mockConsent(String csvFileContent, String fileType){
+        OBWriteFileConsent3 consentRequest = JMockData.mock(OBWriteFileConsent3.class);
         consentRequest.getData().getInitiation().fileHash(computeSHA256FullHash(csvFileContent));
         consentRequest.getData().getInitiation().fileReference("FileRef001");
         consentRequest.getData().getInitiation().fileType(fileType);
@@ -239,14 +239,14 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param consentRequest
      * @return
      */
-    private static final FRFileConsent2 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent2 consentRequest){
-        FRFileConsent2 frFileConsent2 = JMockData.mock(FRFileConsent2.class);
-        frFileConsent2.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
-        frFileConsent2.setId(fileConsentId);
-        frFileConsent2.setFileContent(csvFileContent);
-        frFileConsent2.setPayments(Collections.emptyList());
-        frFileConsent2.setWriteFileConsent(consentRequest);
-        return frFileConsent2;
+    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent5 frFileConsent5 = JMockData.mock(FRFileConsent5.class);
+        frFileConsent5.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent5.setId(fileConsentId);
+        frFileConsent5.setFileContent(csvFileContent);
+        frFileConsent5.setPayments(Collections.emptyList());
+        frFileConsent5.setWriteFileConsent(consentRequest);
+        return frFileConsent5;
     }
 
     /**

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
@@ -30,10 +30,10 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVVa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1.payments.FileConsent2Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -77,11 +77,16 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 public class CSVFilePaymentConsentsRsStoreApiController {
 
     private final TppRepository tppRepository;
-    private final FileConsent2Repository fileConsentRepository;
+    private final FileConsent5Repository fileConsentRepository;
     private final ResourceLinkService resourceLinkService;
     private ConsentMetricService consentMetricService;
 
-    public CSVFilePaymentConsentsRsStoreApiController(@Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService, TppRepository tppRepository, FileConsent2Repository fileConsentRepository, ResourceLinkService resourceLinkService) {
+    public CSVFilePaymentConsentsRsStoreApiController(
+            @Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService,
+            TppRepository tppRepository,
+            FileConsent5Repository fileConsentRepository,
+            ResourceLinkService resourceLinkService
+    ) {
         this.tppRepository = tppRepository;
         this.fileConsentRepository = fileConsentRepository;
         this.resourceLinkService = resourceLinkService;
@@ -152,7 +157,7 @@ public class CSVFilePaymentConsentsRsStoreApiController {
         log.trace("CVS store controller.");
         log.trace("Received '{}'.", fileParam);
 
-        final FRFileConsent2 fileConsent = fileConsentRepository.findById(consentId)
+        final FRFileConsent5 fileConsent = fileConsentRepository.findById(consentId)
                 .orElseThrow(() -> new OBErrorResponseException(
                         HttpStatus.BAD_REQUEST,
                         OBRIErrorResponseCategory.REQUEST_INVALID,

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
@@ -30,10 +30,10 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVVa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1.payments.FileConsent2Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -72,16 +72,21 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
 @Controller("CSVFilePaymentConsentsApiV3.1.3")
-@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp"})
+@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp"})
 @Slf4j
 public class CSVFilePaymentConsentsRsStoreApiController {
 
     private final TppRepository tppRepository;
-    private final FileConsent2Repository fileConsentRepository;
+    private final FileConsent5Repository fileConsentRepository;
     private final ResourceLinkService resourceLinkService;
     private ConsentMetricService consentMetricService;
 
-    public CSVFilePaymentConsentsRsStoreApiController(@Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService, TppRepository tppRepository, FileConsent2Repository fileConsentRepository, ResourceLinkService resourceLinkService) {
+    public CSVFilePaymentConsentsRsStoreApiController(
+            @Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService,
+            TppRepository tppRepository,
+            FileConsent5Repository fileConsentRepository,
+            ResourceLinkService resourceLinkService
+    ) {
         this.tppRepository = tppRepository;
         this.fileConsentRepository = fileConsentRepository;
         this.resourceLinkService = resourceLinkService;
@@ -149,7 +154,7 @@ public class CSVFilePaymentConsentsRsStoreApiController {
         log.trace("CVS store controller.");
         log.trace("Received '{}'.", fileParam);
 
-        final FRFileConsent2 fileConsent = fileConsentRepository.findById(consentId)
+        final FRFileConsent5 fileConsent = fileConsentRepository.findById(consentId)
                 .orElseThrow(() -> new OBErrorResponseException(
                         HttpStatus.BAD_REQUEST,
                         OBRIErrorResponseCategory.REQUEST_INVALID,

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -30,17 +30,21 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHead
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.aspsp.rs.store.ForgerockOpenbankingRsStoreApplication;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1.payments.FileConsent2Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1.payment.FRFileConsent2;
+import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
 import com.forgerock.openbanking.common.model.version.OBVersion;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.extensions.lbg.test.MockTppHelper;
 import com.forgerock.openbanking.integration.test.support.SpringSecForTest;
 import com.forgerock.openbanking.model.OBRIRole;
 import com.github.jsonzou.jmockdata.JMockData;
-import kong.unirest.*;
+import kong.unirest.HttpResponse;
+import kong.unirest.JacksonObjectMapper;
+import kong.unirest.JsonNode;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.json.JSONArray;
@@ -58,7 +62,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.org.openbanking.OBHeaders;
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBExternalConsentStatus2Code;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse2;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -69,12 +76,17 @@ import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -92,7 +104,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
     @Autowired
     private RSConfiguration rsConfiguration;
     @Autowired
-    private FileConsent2Repository repository;
+    private FileConsent5Repository repository;
     @MockBean
     private TppRepository tppRepository;
 
@@ -121,7 +133,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
         // When
         HttpResponse<OBWriteFileConsentResponse2> response = Unirest.post("https://rs-store:" + port + _URL)
@@ -138,11 +150,11 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         assertThat(response.getStatus()).isEqualTo(201);
         OBWriteFileConsentResponse2 consentResponse = response.getBody();
-        FRFileConsent2 consent = repository.findById(consentResponse.getData().getConsentId()).get();
+        FRFileConsent5 consent = repository.findById(consentResponse.getData().getConsentId()).get();
         assertThat(consent.getPispName()).isEqualTo(MockTppHelper.MOCK_PISP_NAME);
         assertThat(consent.getPispId()).isEqualTo(MockTppHelper.MOCK_PISP_ID);
         assertThat(consent.getId()).isEqualTo(consentResponse.getData().getConsentId());
-        assertThat(consent.getInitiation()).isEqualTo(consentResponse.getData().getInitiation());
+        assertThat(consent.getInitiation()).isEqualTo(toOBWriteFile2DataInitiation(consentResponse.getData().getInitiation()));
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(consentResponse.getData().getStatus());
         assertThat(consent.getObVersion()).isEqualTo(OBVersion.v3_1_2);
     }
@@ -159,9 +171,9 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -180,7 +192,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
         assertThat(response.getStatus()).isEqualTo(200);
-        FRFileConsent2 consent = repository.findById(fileConsentId).get();
+        FRFileConsent5 consent = repository.findById(fileConsentId).get();
         assertThat(consent.getId()).isEqualTo(fileConsentId);
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
         assertThat(consent.getFileContent()).isEqualTo(file.toString());
@@ -198,9 +210,9 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -219,7 +231,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
         assertThat(response.getStatus()).isEqualTo(200);
-        FRFileConsent2 consent = repository.findById(fileConsentId).get();
+        FRFileConsent5 consent = repository.findById(fileConsentId).get();
         assertThat(consent.getId()).isEqualTo(fileConsentId);
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
         assertThat(consent.getFileContent()).isEqualTo(file.toString());
@@ -296,9 +308,9 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
         MockTppHelper.setupMockTpp(tppRepository);
 
-        OBWriteFileConsent2 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent2 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -328,8 +340,8 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
      * @return
      */
     @Ignore
-    private static final OBWriteFileConsent2 mockConsent(String fileContent, String fileType){
-        OBWriteFileConsent2 consentRequest = JMockData.mock(OBWriteFileConsent2.class);
+    private static final OBWriteFileConsent3 mockConsent(String fileContent, String fileType){
+        OBWriteFileConsent3 consentRequest = JMockData.mock(OBWriteFileConsent3.class);
         consentRequest.getData().getInitiation().fileHash(computeSHA256FullHash(fileContent));
         consentRequest.getData().getInitiation().fileReference("ref-001");
         consentRequest.getData().getInitiation().fileType(fileType);
@@ -348,8 +360,8 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
      * @return
      */
     @Ignore
-    private static final FRFileConsent2 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent2 consentRequest){
-        FRFileConsent2 frFileConsent2 = JMockData.mock(FRFileConsent2.class);
+    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent5 frFileConsent2 = JMockData.mock(FRFileConsent5.class);
         frFileConsent2.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
         frFileConsent2.setId(fileConsentId);
         frFileConsent2.setFileContent(csvFileContent);

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -314,6 +314,48 @@ rs-discovery:
         getFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.4/pisp/file-payments/{FilePaymentId}
         getFilePaymentReport: ${rs-discovery.base-url}/open-banking/v3.1.4/pisp/file-payments/{ConsentId}/report-file
         getFilePaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.4/pisp/file-payments/{FilePaymentId}/payment-details
+      v_3_1_5:
+        createDomesticPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payment-consents
+        getDomesticPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payment-consents/{ConsentId}
+        getDomesticPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation
+        createDomesticPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payments
+        getDomesticPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payments/{DomesticPaymentId}
+        getDomesticPaymentsDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-payments/{DomesticPaymentId}/payment-details
+        createDomesticScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-scheduled-payment-consents
+        getDomesticScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-scheduled-payment-consents/{ConsentId}
+        createDomesticScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-scheduled-payments
+        getDomesticScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}
+        getDomesticScheduledPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}/payment-details
+        createDomesticStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-standing-order-consents
+        getDomesticStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-standing-order-consents/{ConsentId}
+        createDomesticStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-standing-orders
+        getDomesticStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-standing-orders/{DomesticStandingOrderId}
+        getDomesticStandingOrderPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/domestic-standing-orders/{DomesticStandingOrderId}/payment-details
+        createInternationalPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payment-consents
+        getInternationalPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payment-consents/{ConsentId}
+        getInternationalPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payment-consents/{ConsentId}/funds-confirmation
+        createInternationalPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payments
+        getInternationalPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payments/{InternationalPaymentId}
+        getInternationalPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-payments/{InternationalPaymentId}/payment-details
+        createInternationalScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payment-consents
+        getInternationalScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payment-consents/{ConsentId}
+        getInternationalScheduledPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation
+        createInternationalScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payments
+        getInternationalScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}
+        getInternationalScheduledPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}/payment-details
+        createInternationalStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-standing-order-consents
+        getInternationalStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-standing-order-consents/{ConsentId}
+        createInternationalStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-standing-orders
+        getInternationalStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-standing-orders/{InternationalStandingOrderId}
+        getInternationalStandingOrderPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}/payment-details
+        createFilePaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payment-consents
+        getFilePaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payment-consents/{ConsentId}
+        createFilePaymentFile: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payment-consents/{ConsentId}/file
+        getFilePaymentFile: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payment-consents/{ConsentId}/file
+        createFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payments
+        getFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payments/{FilePaymentId}
+        getFilePaymentReport: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payments/{ConsentId}/report-file
+        getFilePaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.5/pisp/file-payments/{FilePaymentId}/payment-details
     accounts:
       v_1_1:
         createAccountRequest: ${rs-discovery.base-url}/open-banking/v1.1/account-requests

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.75</version>
+        <version>1.0.77</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -49,7 +49,7 @@
         <ob-jwkms.version>1.1.71</ob-jwkms.version>
         <ob-auth.version>1.0.59</ob-auth.version>
         <ob-directory.version>1.4.74</ob-directory.version>
-        <ob-aspsp.version>1.0.91</ob-aspsp.version>
+        <ob-aspsp.version>1.0.92</ob-aspsp.version>
         <ob-clients.version>1.0.36</ob-clients.version>
         <ob-extensions.version>1.0.12</ob-extensions.version>
     </properties>


### PR DESCRIPTION
## Description
This PR brings in the required changes from `openbanking-aspsp` and `openbanking-uk-datamodel` (via the parent pom) to support v3.1.5 of the Payments API.
It also makes the required changes to support CSV File based payments for LBG and lists the new v3.1.5 endpoints within`forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml` (so that they appear in the Discovery API).

## Impacted Areas in Application
List general components of the application that this PR will affect:

* rs-api
* rs-store