### PR TITLE
Bumped version of aspsp to include validation of the b64 claims header (#280)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <ob-jwkms.version>1.1.71</ob-jwkms.version>
         <ob-auth.version>1.0.59</ob-auth.version>
         <ob-directory.version>1.4.74</ob-directory.version>
-        <ob-aspsp.version>1.0.96</ob-aspsp.version>
+        <ob-aspsp.version>1.0.97</ob-aspsp.version>
         <ob-clients.version>1.0.36</ob-clients.version>
         <ob-extensions.version>1.0.12</ob-extensions.version>
     </properties>


### PR DESCRIPTION
Bumped version of aspsp to include validation of the b64 claims header in a detached JWS (#280)

## Description
Validation has been added to ensure the b64 claims header is present and set to false in a detached JWS, if the version is v.3.1.3 or earlier.

If the version is v3.1.4 or later, the application ensures the b64 claims header is not included.

Additionally, validation has been added to ensure that a null detached JWS cannot be provided if the verification of detached signatures is enabled in the config. 

## Impacted Areas in Application
List general components of the application that this PR will affect:
* rs-api



