### PR TITLE
Migration of mongo data from v3.1.2 to v3.1.6 (#279)

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -51,6 +51,11 @@
             <groupId>com.forgerock.openbanking.clients</groupId>
             <artifactId>forgerock-openbanking-analytics-webclient</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.mongobee</groupId>
+            <artifactId>mongobee</artifactId>
+        </dependency>
         <dependency>
             <groupId>dev.openbanking4.spring.security</groupId>
             <artifactId>spring-security-multi-auth-starter</artifactId>
@@ -84,6 +89,7 @@
             <groupId>com.forgerock.openbanking</groupId>
             <artifactId>forgerock-openbanking-uk-extensions</artifactId>
         </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>com.forgerock.openbanking.aspsp</groupId>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
@@ -26,12 +26,15 @@ import com.forgerock.openbanking.common.CookieWebSecurityConfiguration;
 import com.forgerock.openbanking.common.EnableSslClient;
 import com.forgerock.openbanking.common.model.onboarding.ManualRegistrationApplication;
 import com.forgerock.openbanking.model.Tpp;
+import com.github.mongobee.Mongobee;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
@@ -60,6 +63,14 @@ public class ForgerockOpenbankingRsStoreApplication{
                 config.exposeIdsFor(ManualRegistrationApplicationRepository.class, ManualRegistrationApplication.class);
             }
         };
+    }
+
+    @Bean
+    public Mongobee mongobee(@Value("${spring.data.mongodb.uri}") String mongoDbUrl, MongoTemplate mongoTemplate){
+        Mongobee mongobee = new Mongobee(mongoDbUrl);
+        mongobee.setChangeLogsScanPackage("com.forgerock.openbanking.aspsp.rs.store.repository");
+        mongobee.setMongoTemplate(mongoTemplate);
+        return mongobee;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.78</version>
+        <version>1.0.79</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -49,7 +49,7 @@
         <ob-jwkms.version>1.1.71</ob-jwkms.version>
         <ob-auth.version>1.0.59</ob-auth.version>
         <ob-directory.version>1.4.74</ob-directory.version>
-        <ob-aspsp.version>1.0.97</ob-aspsp.version>
+        <ob-aspsp.version>1.0.98</ob-aspsp.version>
         <ob-clients.version>1.0.36</ob-clients.version>
         <ob-extensions.version>1.0.12</ob-extensions.version>
     </properties>


### PR DESCRIPTION
Added Mongobee for migration of mongo data. Bumped version of aspsp to migrate OB objects from v3.1.2 to v3.1.6 (#279)

Mongobee is essentially a Mongo equivalent of liquibase. It runs when the application starts up and checks to see if any new ChangeLogs need to be applied.

## Impacted Areas in Application
* rs-store
