### PR TITLE
Expect TPPs jws sigs to have correct issuer field

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -40,6 +40,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.forgerock.openbanking</groupId>
+            <artifactId>forgerock-openbanking-model</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.forgerock.openbanking.common</groupId>
             <artifactId>forgerock-openbanking-common</artifactId>
         </dependency>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
@@ -42,7 +42,7 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
 
 @SpringBootApplication(scanBasePackages = "com.forgerock.openbanking")
-@EnableMongoRepositories
+@EnableMongoRepositories(basePackages = "com.forgerock.openbanking")
 @EnableMongoAuditing
 @EnableDiscoveryClient
 @EnableSslClient

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ForgerockOpenbankingRsStoreApplication.java
@@ -21,7 +21,7 @@
 package com.forgerock.openbanking.aspsp.rs.store;
 
 import com.forgerock.openbanking.aspsp.rs.store.repository.ManualRegistrationApplicationRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.common.CookieWebSecurityConfiguration;
 import com.forgerock.openbanking.common.EnableSslClient;
 import com.forgerock.openbanking.common.model.onboarding.ManualRegistrationApplication;

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVPa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVValidationFactory;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVPa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVValidationFactory;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/MockTppHelper.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/MockTppHelper.java
@@ -20,7 +20,7 @@
  */
 package com.forgerock.openbanking.extensions.lbg.test;
 
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.model.Tpp;
 
 import static org.mockito.ArgumentMatchers.eq;

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.aspsp.rs.store.ForgerockOpenbankingRsStoreApplication;
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_4/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_4/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.aspsp.rs.store.ForgerockOpenbankingRsStoreApplication;
-import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
+import com.forgerock.openbanking.repositories.TppRepository;
 import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
 import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -40,4 +40,11 @@
     <modules>
         <module>forgerock-openbanking-metrics-services</module>
     </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.forgerock.openbanking</groupId>
+            <artifactId>forgerock-openbanking-model</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,14 +45,14 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-analytics.version>1.1.54</ob-analytics.version>
-        <ob-jwkms.version>1.1.75</ob-jwkms.version>
-        <ob-auth.version>1.0.64</ob-auth.version>
-        <ob-directory.version>1.4.77-SNAPSHOT</ob-directory.version>
-        <ob-aspsp.version>1.0.107-SNAPSHOT</ob-aspsp.version>
+        <ob-analytics.version>1.1.55</ob-analytics.version>
+        <ob-jwkms.version>1.1.76</ob-jwkms.version>
+        <ob-auth.version>1.0.65</ob-auth.version>
+        <ob-directory.version>1.4.77</ob-directory.version>
+        <ob-aspsp.version>1.0.107</ob-aspsp.version>
         <ob-clients.version>1.0.44</ob-clients.version>
-        <ob-extensions.version>1.0.20-SNAPSHOT</ob-extensions.version>
-        <ob-commons.version>1.0.87-SNAPSHOT</ob-commons.version>
+        <ob-extensions.version>1.0.20</ob-extensions.version>
+        <ob-commons.version>1.0.86</ob-commons.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <ob-directory.version>1.4.77-SNAPSHOT</ob-directory.version>
         <ob-aspsp.version>1.0.107-SNAPSHOT</ob-aspsp.version>
         <ob-clients.version>1.0.44</ob-clients.version>
-        <ob-extensions.version>1.0.19</ob-extensions.version>
-        <ob-commons.version>1.0.86</ob-commons.version>
+        <ob-extensions.version>1.0.20-SNAPSHOT</ob-extensions.version>
+        <ob-commons.version>1.0.87-SNAPSHOT</ob-commons.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,12 @@
     <properties>
         <ob-analytics.version>1.1.54</ob-analytics.version>
         <ob-jwkms.version>1.1.75</ob-jwkms.version>
-        <ob-auth.version>1.0.63</ob-auth.version>
-        <ob-directory.version>1.4.76</ob-directory.version>
-        <ob-aspsp.version>1.0.106</ob-aspsp.version>
-        <ob-clients.version>1.0.41</ob-clients.version>
+        <ob-auth.version>1.0.64</ob-auth.version>
+        <ob-directory.version>1.4.77-SNAPSHOT</ob-directory.version>
+        <ob-aspsp.version>1.0.107-SNAPSHOT</ob-aspsp.version>
+        <ob-clients.version>1.0.44</ob-clients.version>
         <ob-extensions.version>1.0.19</ob-extensions.version>
+        <ob-commons.version>1.0.86</ob-commons.version>
     </properties>
 
     <modules>
@@ -67,6 +68,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.forgerock.openbanking</groupId>
+                <artifactId>forgerock-openbanking-model</artifactId>
+                <version>${ob-commons.version}</version>
+            </dependency>
 
             <!-- OpenBanking -->
             <dependency>


### PR DESCRIPTION
According to the OB spec, when at TPP signs messages with an OB cert,
the iss field of the jws header should be set to
{{orgId}}/{{softwareId}} where the orgId is the OpenBanking organisation
with which the certificates used belong to, and sofware Id indicates the
Software Statement or software client Id of the Open Banking registered
TPP.

See issue https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/12
