### PR TITLE
Bumped version of aspsp and uk-extensions. Using FR model objects in Mongo document classes (#296)

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidationService;
 import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -62,7 +62,6 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collections;
 
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRFileConsentConverter.toFRFileConsent2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
@@ -144,12 +143,12 @@ public class CSVFilePaymentConsentsApiController {
     ) throws OBErrorResponseException {
         log.trace("CVS controller.");
         log.trace("Received '{}'.", fileParam);
-        FRFileConsent5 consent = filePaymentService.getPayment(consentId);
+        FRFileConsent consent = filePaymentService.getPayment(consentId);
         try {
             CSVParser parser = CSVParserFactory.parse(CSVFilePaymentType.fromStringType(consent.getFileType().getFileType()), fileParam);
             CSVFilePayment filePayment = parser.parse().getCsvFilePayment();
-            CSVValidationService.Consent.numTransactions(toFRFileConsent2(consent), filePayment);
-            CSVValidationService.Consent.controlSum(toFRFileConsent2(consent), filePayment);
+            CSVValidationService.Consent.numTransactions(consent, filePayment);
+            CSVValidationService.Consent.controlSum(consent, filePayment);
         } catch (OBErrorException | CSVErrorException e) {
             if (e instanceof CSVErrorException) {
                 throw new OBErrorResponseException(((CSVErrorException) e).getCsvErrorType().getHttpStatus(), OBRIErrorResponseCategory.REQUEST_INVALID, "csv error", ((CSVErrorException) e).getOBError());

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
@@ -29,7 +29,7 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidationService;
 import com.forgerock.openbanking.aspsp.rs.wrappper.RSEndpointWrapperService;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.exceptions.OBErrorException;
@@ -63,7 +63,6 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.Collections;
 
-import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRFileConsentConverter.toFRFileConsent2;
 import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE_FORMAT;
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
@@ -143,12 +142,12 @@ public class CSVFilePaymentConsentsApiController {
     ) throws OBErrorResponseException {
         log.trace("CVS controller.");
         log.trace("Received '{}'.", fileParam);
-        FRFileConsent5 consent = filePaymentService.getPayment(consentId);
+        FRFileConsent consent = filePaymentService.getPayment(consentId);
         try {
             CSVParser parser = CSVParserFactory.parse(CSVFilePaymentType.fromStringType(consent.getFileType().getFileType()), fileParam);
             CSVFilePayment filePayment = parser.parse().getCsvFilePayment();
-            CSVValidationService.Consent.numTransactions(toFRFileConsent2(consent), filePayment);
-            CSVValidationService.Consent.controlSum(toFRFileConsent2(consent), filePayment);
+            CSVValidationService.Consent.numTransactions(consent, filePayment);
+            CSVValidationService.Consent.controlSum(consent, filePayment);
         } catch (OBErrorException | CSVErrorException e) {
             if (e instanceof CSVErrorException) {
                 throw new OBErrorResponseException(((CSVErrorException) e).getCsvErrorType().getHttpStatus(), OBRIErrorResponseCategory.REQUEST_INVALID, "csv error", ((CSVErrorException) e).getOBError());

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_2/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_2/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -30,8 +30,8 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
-import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.constants.OIDCConstants;
@@ -82,6 +82,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
 import static com.forgerock.openbanking.integration.test.support.JWT.jws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -154,7 +155,7 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -193,7 +194,7 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -241,14 +242,14 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param consentRequest
      * @return
      */
-    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
-        FRFileConsent5 frFileConsent5 = JMockData.mock(FRFileConsent5.class);
-        frFileConsent5.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
-        frFileConsent5.setId(fileConsentId);
-        frFileConsent5.setFileContent(csvFileContent);
-        frFileConsent5.setPayments(Collections.emptyList());
-        frFileConsent5.setWriteFileConsent(consentRequest);
-        return frFileConsent5;
+    private static final FRFileConsent mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent frFileConsent = JMockData.mock(FRFileConsent.class);
+        frFileConsent.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent.setId(fileConsentId);
+        frFileConsent.setFileContent(csvFileContent);
+        frFileConsent.setPayments(Collections.emptyList());
+        frFileConsent.setWriteFileConsent(toFRWriteFileConsent(consentRequest));
+        return frFileConsent;
     }
 
     /**

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_5/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_5/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -30,8 +30,8 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFile
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
-import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.services.store.RsStoreGateway;
 import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
 import com.forgerock.openbanking.constants.OIDCConstants;
@@ -82,6 +82,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
 import static com.forgerock.openbanking.integration.test.support.JWT.jws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
@@ -154,7 +155,7 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -192,7 +193,7 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
 
         given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
         given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
@@ -239,14 +240,14 @@ public class CSVFilePaymentConsentsRsApiControllerIT {
      * @param consentRequest
      * @return
      */
-    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
-        FRFileConsent5 frFileConsent5 = JMockData.mock(FRFileConsent5.class);
-        frFileConsent5.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
-        frFileConsent5.setId(fileConsentId);
-        frFileConsent5.setFileContent(csvFileContent);
-        frFileConsent5.setPayments(Collections.emptyList());
-        frFileConsent5.setWriteFileConsent(consentRequest);
-        return frFileConsent5;
+    private static final FRFileConsent mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent frFileConsent = JMockData.mock(FRFileConsent.class);
+        frFileConsent.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent.setId(fileConsentId);
+        frFileConsent.setFileContent(csvFileContent);
+        frFileConsent.setPayments(Collections.emptyList());
+        frFileConsent.setWriteFileConsent(toFRWriteFileConsent(consentRequest));
+        return frFileConsent;
     }
 
     /**

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
@@ -30,10 +30,10 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVVa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
-import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -77,14 +77,14 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 public class CSVFilePaymentConsentsRsStoreApiController {
 
     private final TppRepository tppRepository;
-    private final FileConsent5Repository fileConsentRepository;
+    private final FileConsentRepository fileConsentRepository;
     private final ResourceLinkService resourceLinkService;
     private ConsentMetricService consentMetricService;
 
     public CSVFilePaymentConsentsRsStoreApiController(
             @Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService,
             TppRepository tppRepository,
-            FileConsent5Repository fileConsentRepository,
+            FileConsentRepository fileConsentRepository,
             ResourceLinkService resourceLinkService
     ) {
         this.tppRepository = tppRepository;
@@ -157,7 +157,7 @@ public class CSVFilePaymentConsentsRsStoreApiController {
         log.trace("CVS store controller.");
         log.trace("Received '{}'.", fileParam);
 
-        final FRFileConsent5 fileConsent = fileConsentRepository.findById(consentId)
+        final FRFileConsent fileConsent = fileConsentRepository.findById(consentId)
                 .orElseThrow(() -> new OBErrorResponseException(
                         HttpStatus.BAD_REQUEST,
                         OBRIErrorResponseCategory.REQUEST_INVALID,

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
@@ -30,10 +30,10 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVVa
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.parser.CSVParser;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
 import com.forgerock.openbanking.common.conf.discovery.ResourceLinkService;
-import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
@@ -77,14 +77,14 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 public class CSVFilePaymentConsentsRsStoreApiController {
 
     private final TppRepository tppRepository;
-    private final FileConsent5Repository fileConsentRepository;
+    private final FileConsentRepository fileConsentRepository;
     private final ResourceLinkService resourceLinkService;
     private ConsentMetricService consentMetricService;
 
     public CSVFilePaymentConsentsRsStoreApiController(
             @Qualifier("webClientConsentMetricService") ConsentMetricService consentMetricService,
             TppRepository tppRepository,
-            FileConsent5Repository fileConsentRepository,
+            FileConsentRepository fileConsentRepository,
             ResourceLinkService resourceLinkService
     ) {
         this.tppRepository = tppRepository;
@@ -154,7 +154,7 @@ public class CSVFilePaymentConsentsRsStoreApiController {
         log.trace("CVS store controller.");
         log.trace("Received '{}'.", fileParam);
 
-        final FRFileConsent5 fileConsent = fileConsentRepository.findById(consentId)
+        final FRFileConsent fileConsent = fileConsentRepository.findById(consentId)
                 .orElseThrow(() -> new OBErrorResponseException(
                         HttpStatus.BAD_REQUEST,
                         OBRIErrorResponseCategory.REQUEST_INVALID,

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_2/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -30,10 +30,10 @@ import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHead
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
 import com.forgerock.openbanking.aspsp.rs.store.ForgerockOpenbankingRsStoreApplication;
 import com.forgerock.openbanking.aspsp.rs.store.repository.TppRepository;
-import com.forgerock.openbanking.aspsp.rs.store.repository.v3_1_5.payments.FileConsent5Repository;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
 import com.forgerock.openbanking.common.conf.RSConfiguration;
-import com.forgerock.openbanking.common.model.openbanking.forgerock.ConsentStatusCode;
-import com.forgerock.openbanking.common.model.openbanking.v3_1_5.payment.FRFileConsent5;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
 import com.forgerock.openbanking.common.model.version.OBVersion;
 import com.forgerock.openbanking.exceptions.OBErrorException;
 import com.forgerock.openbanking.extensions.lbg.test.MockTppHelper;
@@ -82,11 +82,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileDataInitiation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 @Slf4j
 @RunWith(SpringRunner.class)
@@ -104,7 +105,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
     @Autowired
     private RSConfiguration rsConfiguration;
     @Autowired
-    private FileConsent5Repository repository;
+    private FileConsentRepository repository;
     @MockBean
     private TppRepository tppRepository;
 
@@ -150,11 +151,11 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         assertThat(response.getStatus()).isEqualTo(201);
         OBWriteFileConsentResponse2 consentResponse = response.getBody();
-        FRFileConsent5 consent = repository.findById(consentResponse.getData().getConsentId()).get();
+        FRFileConsent consent = repository.findById(consentResponse.getData().getConsentId()).get();
         assertThat(consent.getPispName()).isEqualTo(MockTppHelper.MOCK_PISP_NAME);
         assertThat(consent.getPispId()).isEqualTo(MockTppHelper.MOCK_PISP_ID);
         assertThat(consent.getId()).isEqualTo(consentResponse.getData().getConsentId());
-        assertThat(consent.getInitiation()).isEqualTo(toOBWriteFile2DataInitiation(consentResponse.getData().getInitiation()));
+        assertThat(consent.getInitiation()).isEqualTo(toFRWriteFileDataInitiation(consentResponse.getData().getInitiation()));
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(consentResponse.getData().getStatus());
         assertThat(consent.getObVersion()).isEqualTo(OBVersion.v3_1_2);
     }
@@ -173,7 +174,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -192,7 +193,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
         assertThat(response.getStatus()).isEqualTo(200);
-        FRFileConsent5 consent = repository.findById(fileConsentId).get();
+        FRFileConsent consent = repository.findById(fileConsentId).get();
         assertThat(consent.getId()).isEqualTo(fileConsentId);
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
         assertThat(consent.getFileContent()).isEqualTo(file.toString());
@@ -212,7 +213,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -231,7 +232,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
         // Then
         log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
         assertThat(response.getStatus()).isEqualTo(200);
-        FRFileConsent5 consent = repository.findById(fileConsentId).get();
+        FRFileConsent consent = repository.findById(fileConsentId).get();
         assertThat(consent.getId()).isEqualTo(fileConsentId);
         assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
         assertThat(consent.getFileContent()).isEqualTo(file.toString());
@@ -310,7 +311,7 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
 
         OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
 
-        FRFileConsent5 existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
 
         repository.save(existingConsent);
 
@@ -360,13 +361,13 @@ public class CSVFilePaymentConsentsRsStoreApiControllerIT {
      * @return
      */
     @Ignore
-    private static final FRFileConsent5 mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
-        FRFileConsent5 frFileConsent2 = JMockData.mock(FRFileConsent5.class);
+    private static final FRFileConsent mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent frFileConsent2 = JMockData.mock(FRFileConsent.class);
         frFileConsent2.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
         frFileConsent2.setId(fileConsentId);
         frFileConsent2.setFileContent(csvFileContent);
         frFileConsent2.setPayments(Collections.emptyList());
-        frFileConsent2.setWriteFileConsent(consentRequest);
+        frFileConsent2.setWriteFileConsent(toFRWriteFileConsent(consentRequest));
         return frFileConsent2;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <ob-jwkms.version>1.1.76</ob-jwkms.version>
         <ob-auth.version>1.0.65</ob-auth.version>
         <ob-directory.version>1.4.77</ob-directory.version>
-        <ob-aspsp.version>1.0.108-SNAPSHOT</ob-aspsp.version>
+        <ob-aspsp.version>1.0.108</ob-aspsp.version>
         <ob-clients.version>1.0.44</ob-clients.version>
-        <ob-extensions.version>1.0.21-SNAPSHOT</ob-extensions.version>
+        <ob-extensions.version>1.0.21</ob-extensions.version>
         <ob-commons.version>1.0.86</ob-commons.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <ob-jwkms.version>1.1.75</ob-jwkms.version>
         <ob-auth.version>1.0.63</ob-auth.version>
         <ob-directory.version>1.4.76</ob-directory.version>
-        <ob-aspsp.version>1.0.105</ob-aspsp.version>
+        <ob-aspsp.version>1.0.106-SNAPSHOT</ob-aspsp.version>
         <ob-clients.version>1.0.41</ob-clients.version>
-        <ob-extensions.version>1.0.18</ob-extensions.version>
+        <ob-extensions.version>1.0.19-SNAPSHOT</ob-extensions.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <ob-jwkms.version>1.1.75</ob-jwkms.version>
         <ob-auth.version>1.0.63</ob-auth.version>
         <ob-directory.version>1.4.76</ob-directory.version>
-        <ob-aspsp.version>1.0.106-SNAPSHOT</ob-aspsp.version>
+        <ob-aspsp.version>1.0.107-SNAPSHOT</ob-aspsp.version>
         <ob-clients.version>1.0.41</ob-clients.version>
-        <ob-extensions.version>1.0.19-SNAPSHOT</ob-extensions.version>
+        <ob-extensions.version>1.0.20-SNAPSHOT</ob-extensions.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Description
Bumped version of aspsp and uk-extensions. Using FR model objects in Mongo document classes (#296)
The change in aspsp is significant and introduces the following changes:

* Removed all unused FR payment consent and submission mongo "documents" and repositories.
* Moved the remaining FR documents and repositories into one folder.
* Removed the number suffix from the FR documents and repositories (e.g. we now just have FRDomesticConsent).
* Deprecated the legacy FR documents which we've had to retain for migration purposes (they've been placed in a legacy package).
* Fixed idempotent checks in controllers and made logging more consistent.

This means that when a new version of the Payments API introduces new OB model objects, we do not need to add new mongo "documents" and corresponding repositories. Instead, these classes can remain as they are and we no longer have to switch all of the existing controllers to use new repositories and document classes, thereby saving considerable effort.

Since the Read/Write API is now stable and any changes tend to be minimal (usually involving new fields), any new OB model objects will need to be added to the (mostly auto generated) controllers (as is currently the case). However, it will then only be necessary to write new converters methods (following the established pattern in other controllers) for the new objects. It should not be necessary to change the repositories or the high level document classes, thereby making the addition of new OB model objects considerably less painful.

## Impacted Areas in Application
This affects these applications:
* rs-api
* rs-store


