### PR TITLE
635 support obwac and obseal as transport and signing certs for tpps

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>3.1.6-smiths-rc2</version>
+         <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -28,13 +28,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>3.1.6-smiths-rc2</version>
+        <version>2.9.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>3.1.6-smiths-rc2</version>
+    <version>2.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.86</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -49,7 +49,7 @@
         <ob-jwkms.version>1.1.76</ob-jwkms.version>
         <ob-auth.version>1.0.65</ob-auth.version>
         <ob-directory.version>1.4.77</ob-directory.version>
-        <ob-aspsp.version>1.0.110</ob-aspsp.version>
+        <ob-aspsp.version>1.0.112</ob-aspsp.version>
         <ob-clients.version>1.0.44</ob-clients.version>
         <ob-extensions.version>1.0.21</ob-extensions.version>
         <ob-commons.version>1.0.86</ob-commons.version>


### PR DESCRIPTION
## Description
- Support onboarding with an OBWac and OBSeal certificate.
- Payment `Refund` fixes [14](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/14)
- Bumped latest starter parent [version 1.0.86](https://github.com/OpenBankingToolkit/openbanking-parent/releases/tag/1.0.86)
- Bumped latest uk extensions [version 1.0.23](https://github.com/OpenBankingToolkit/openbanking-uk-extensions/releases/tag/1.0.23)
## Impacted Areas in Application
List general components of the application that this PR will affect:
* as-rs
* as-api
## Issues reference
- [Issue 635](https://github.com/ForgeCloud/ob-deploy/issues/635)
- [Issue 14](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/14) ([16](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/16))