### PR TITLE
19: Default read/write api version is 3.1.6

### DIFF
--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application-native.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application-native.yml
@@ -40,6 +40,8 @@ rs:
 
 rs-discovery:
   base-url: https://${rs-discovery.hostname}:8074
+  read-write-api:
+    version: 3.1.6
 
 shop:
   port: ${scgw.port}

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -85,6 +85,8 @@ rs-simulator:
 rs-discovery:
   hostname: matls.rs.aspsp.${dns.hosts.root}
   base-url: https://${rs-discovery.hostname}
+  read-write-api:
+    version: 3.1.6
   apis:
     payments:
       v_1_1:


### PR DESCRIPTION
For this next round of deployment we will have the default API version set to 3.1.6

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/19