### PR TITLE
30: cvs file payment details

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_0/CSVFilePaymentConsentsRsStoreApiController.java
@@ -20,9 +20,9 @@
  */
 package com.forgerock.openbanking.aspsp.rs.store.ext.lbg.file.payment.csv.api.v3_0;
 
+import com.forgerock.openbanking.analytics.services.ConsentMetricService;
 import com.forgerock.openbanking.api.annotations.OBReference;
 import com.forgerock.openbanking.api.annotations.OpenBankingAPI;
-import com.forgerock.openbanking.analytics.services.ConsentMetricService;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.exception.CSVErrorException;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVFilePaymentType;
 import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVParserFactory;
@@ -38,13 +38,7 @@ import com.forgerock.openbanking.exceptions.OBErrorResponseException;
 import com.forgerock.openbanking.model.error.OBRIErrorResponseCategory;
 import com.forgerock.openbanking.model.error.OBRIErrorType;
 import com.forgerock.openbanking.repositories.TppRepository;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import io.swagger.annotations.AuthorizationScope;
+import io.swagger.annotations.*;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -54,17 +48,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.*;
 import uk.org.openbanking.datamodel.error.OBErrorResponse1;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
-import java.util.Collections;
 import java.util.Date;
 
 import static com.forgerock.openbanking.common.services.openbanking.IdempotencyService.validateIdempotencyRequest;
@@ -185,13 +174,12 @@ public class CSVFilePaymentConsentsRsStoreApiController {
         // We parse the file and check metadata against the parsed file
         try {
             CSVParser parser = CSVParserFactory.parse(CSVFilePaymentType.fromStringType(fileConsent.getFileType().getFileType()), fileParam);
-            CSVFilePayment paymentFile = parser.parse().getCsvFilePayment();
-            CSVValidationFactory.getValidationServiceInstance(paymentFile).validate();
+            CSVFilePayment csvPaymentFile = parser.parse().getCsvFilePayment();
+            CSVValidationFactory.getValidationServiceInstance(csvPaymentFile).validate();
 
-            //PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(fileConsent.getFileType(), fileParam);
             log.info("Successfully parsed file of type: '{}' for consent: '{}'", fileConsent.getFileType(), fileConsent.getId());
 
-            fileConsent.setPayments(Collections.EMPTY_LIST);
+            fileConsent.setPayments(csvPaymentFile.toFRFilePaymentList());
             fileConsent.setFileContent(fileParam);
             fileConsent.setUpdated(new Date());
             fileConsent.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
@@ -185,10 +185,9 @@ public class CSVFilePaymentConsentsRsStoreApiController {
             CSVFilePayment paymentFile = parser.parse().getCsvFilePayment();
             CSVValidationFactory.getValidationServiceInstance(paymentFile).validate();
 
-            //PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(fileConsent.getFileType(), fileParam);
             log.info("Successfully parsed file of type: '{}' for consent: '{}'", fileConsent.getFileType(), fileConsent.getId());
 
-            fileConsent.setPayments(Collections.EMPTY_LIST);
+            fileConsent.setPayments(paymentFile.toFRFilePaymentList());
             fileConsent.setFileContent(fileParam);
             fileConsent.setUpdated(new Date());
             fileConsent.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <id>prepare-unit-test-coverage</id>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
         <ob-jwkms.version>1.1.80</ob-jwkms.version>
         <ob-auth.version>1.0.69</ob-auth.version>
         <ob-directory.version>1.4.82</ob-directory.version>
-        <ob-aspsp.version>1.3.0</ob-aspsp.version>
+        <ob-aspsp.version>1.3.1</ob-aspsp.version>
         <ob-clients.version>1.1.2</ob-clients.version>
-        <ob-extensions.version>1.2.3</ob-extensions.version>
+        <ob-extensions.version>1.3.0</ob-extensions.version>
         <ob-commons.version>1.1.2</ob-commons.version>
     </properties>
 


### PR DESCRIPTION
## Description
- Bumped apsps version 1.3.1
- Bumped uk extensions version 1.3.0
- Bumped jacoco maven plugin version 0.8.7
- Fix payments metadata for csv file payments

## Impacted Areas in Application
List general components of the application that this PR will affect:

* csv file payment (uk extension)
* aspsp

## Features and fixes
- [Issue 30](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/30)


