### PR TITLE
410: simulated default value for CGP Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ To make these keys available to the jwkms you will need to;
 1. Download the Amster 6.5.1 zip file from backstage
     https://backstage.forgerock.com/downloads/browse/am/archive/productId:amster/minorVersion:6.5/version:6.5.1/releaseType:full
 1. Copy the amster zip file to `forgerock-am/_binaries` and rename the file to `amster.zip`, so that the path is `forgerock-am/_binaries/amster.zip`.
-#### GCP credentials
+#### GCP credentials (only FR team members)
+>The credentials are only accessible for forgerock team members, simulated default value for GCP credentials are set for customers.
+> The test Get account statement file will return 404 - not found when simulated default value is used.
+
+In the `docker-compose file` the service rs-store currently use a volume to access the GCP credentials set in the environment.
 Setting the GCP credentials in local to use it in docker-compose `rs-store` service.
 1. Copy the secret file `ob-gcr.json` from `ob-ci-secrets` repository to your path.
 2. Create the env variable `GCP_CREDENTIALS` in your local system pointed to `ob-gcr.json`.

--- a/docker-compose-profiles.yml
+++ b/docker-compose-profiles.yml
@@ -249,7 +249,7 @@ services:
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:9086,server=y,suspend=n
       GOOGLE_APPLICATION_CREDENTIALS: /opt/ob/config/gcp-credentials.json
     volumes:
-      - ${GCP_CREDENTIALS}:/opt/ob/config/gcp-credentials.json:ro
+      - ${GCP_CREDENTIALS:-./gcp-credentials.json}:/opt/ob/config/gcp-credentials.json:ro
       - ./forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/resources/unfiltered/keystore/keystore.jks:/opt/ob/config/keystore.jks:ro
       - ./forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/resources/unfiltered/keystore/truststore.jks:/etc/ssl/certs/java/cacerts
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,address=*:9086,server=y,suspend=n
       GOOGLE_APPLICATION_CREDENTIALS: /opt/ob/config/gcp-credentials.json
     volumes:
-      - ${GCP_CREDENTIALS}:/opt/ob/config/gcp-credentials.json:ro
+      - ${GCP_CREDENTIALS:-./gcp-credentials.json}:/opt/ob/config/gcp-credentials.json:ro
       - ./forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/resources/unfiltered/keystore/keystore.jks:/opt/ob/config/keystore.jks:ro
       - ./forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/resources/unfiltered/keystore/truststore.jks:/etc/ssl/certs/java/cacerts
     networks:


### PR DESCRIPTION
## Description
Make able the customer, with no access to set protected credentials, run the services with docker-compose 
- Added simulated default value for GCP credentials to run the services

## Feature
- [Feature 410](https://github.com/OpenBankingToolkit/openbanking-reference-implementation/issues/410)

## Impacted Areas in Application
List general components of the application that this PR will affect:

* docker-compose
* RS-STORE


