### PR TITLE
745: sandbox id token key verification fails

### DIFF
--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -1080,7 +1080,7 @@ am:
       oidc-client: ${am.internal.root}/json/realms/root/realms/openbanking/realm-config/agents/OAuth2Client
       authentication: ${am.internal.root}/json/authenticate
     credential:
-      amadmin: sy95jyiquqvjbbquq845gncysh13eax6 # TODO this is a default that shouldn't need to be here. All apps need it but may not use it.#obri
+      amadmin: password # TODO this is a default that shouldn't need to be here. All apps need it but may not use it
 obri:
   token:
     sso: sso_token

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <ob-auth.version>1.1.0</ob-auth.version>
         <ob-directory.version>1.5.0</ob-directory.version>
         <ob-analytics.version>1.3.0</ob-analytics.version>
-        <ob-aspsp.version>1.4.2</ob-aspsp.version>
+        <ob-aspsp.version>1.4.3</ob-aspsp.version>
         <ob-extensions.version>1.4.1</ob-extensions.version>
     </properties>
 


### PR DESCRIPTION
The id_token in the hybrid flow redirect url was not verifyable. We need
to resign the token issued by AM so that we can put the correct key id
(kid) into the jwt - the kid needs to match that of the kid in the OB
jwks_uri in order for it to be verifiable. AM assignes UUID keyIds
rather than the SHA1 hash of the certificate as specified by the OB
directory. See OPENAM-10425.