### PR TITLE
allow for multiple registeration

### DIFF
--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/ApiOBRIExternalCertificates.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/ApiOBRIExternalCertificates.java
@@ -50,7 +50,7 @@ public class ApiOBRIExternalCertificates extends OBRIExternalCertificates {
     private final X509Certificate[] obCA;
 
     public ApiOBRIExternalCertificates(X509Certificate caCertificate, TppStoreService tppStoreService, X509Certificate[] obCA) {
-        super(caCertificate, tppStoreService, obCA);
+        super(caCertificate, obCA);
         this.caCertificate = caCertificate;
         this.tppStoreService = tppStoreService;
         this.obCA = obCA;

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRICertificateConfiguration.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRICertificateConfiguration.java
@@ -48,12 +48,10 @@ public class OBRICertificateConfiguration {
     private Resource obIssuingCertificatePem;
 
     private final KeyStoreService keyStoreService;
-    private final TppStoreService tppStoreService;
 
     @Autowired
-    OBRICertificateConfiguration(KeyStoreService keyStoreService, TppStoreService tppStoreService) {
+    OBRICertificateConfiguration(KeyStoreService keyStoreService) {
         this.keyStoreService = keyStoreService;
-        this.tppStoreService = tppStoreService;
     }
 
     @Bean
@@ -66,6 +64,6 @@ public class OBRICertificateConfiguration {
     public OBRIExternalCertificates obriExternalCertificates() throws Exception {
         X509Certificate externalCACertificate = (X509Certificate) keyStoreService.getKeyStore().getCertificate(externalCaAlias);
         X509Certificate[] obCA = loadOBCertificates(obRootCertificatePem, obIssuingCertificatePem);
-        return new OBRIExternalCertificates(externalCACertificate, tppStoreService, obCA);
+        return new OBRIExternalCertificates(externalCACertificate, obCA);
     }
 }

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRIExternalCertificates.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRIExternalCertificates.java
@@ -20,27 +20,23 @@
  */
 package com.forgerock.openbanking.common;
 
-import com.forgerock.cert.Psd2CertInfo;
-import com.forgerock.cert.psd2.RolesOfPsp;
-import com.forgerock.openbanking.common.services.store.tpp.TppStoreService;
-import com.forgerock.openbanking.model.OBRIRole;
-import com.forgerock.openbanking.model.Tpp;
-import com.forgerock.spring.security.multiauth.configurers.collectors.PSD2Collector;
-import com.forgerock.spring.security.multiauth.configurers.collectors.X509Collector;
-import com.forgerock.spring.security.multiauth.model.granttypes.PSD2GrantType;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.GrantedAuthority;
+import static com.forgerock.openbanking.common.CertificateHelper.isCertificateIssuedByCA;
 
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.forgerock.openbanking.common.CertificateHelper.getCn;
-import static com.forgerock.openbanking.common.CertificateHelper.isCertificateIssuedByCA;
+import com.forgerock.cert.Psd2CertInfo;
+import com.forgerock.cert.psd2.RolesOfPsp;
+import com.forgerock.openbanking.model.OBRIRole;
+import com.forgerock.spring.security.multiauth.configurers.collectors.PSD2Collector;
+import com.forgerock.spring.security.multiauth.model.granttypes.PSD2GrantType;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A common utility for external OBRI certificates.
@@ -54,10 +50,7 @@ public class OBRIExternalCertificates implements PSD2Collector.Psd2AuthoritiesCo
     private final X509Certificate[] obCA;
 
     @Override
-    public Set<GrantedAuthority> getAuthorities(
-            X509Certificate[] certificatesChain, 
-            Psd2CertInfo psd2CertInfo, 
-            RolesOfPsp roles) {
+    public Set<GrantedAuthority> getAuthorities(X509Certificate[] certificatesChain, Psd2CertInfo psd2CertInfo, RolesOfPsp roles) {
         Set<GrantedAuthority> authorities = new HashSet<>();
 
         if (roles != null) {
@@ -79,6 +72,7 @@ public class OBRIExternalCertificates implements PSD2Collector.Psd2AuthoritiesCo
     @Override
     public String getUserName(X509Certificate[] certificatesChain, Psd2CertInfo psd2CertInfo) {
         if (!psd2CertInfo.isPsd2Cert()) {
+            log.info("getUserName() the presented cert is not a PSD2 certificate.");
             return null;
         }
         return psd2CertInfo.getOrganizationId()


### PR DESCRIPTION
Remove the unregistered TPP role and change the getUsername method to return the `authorisationNumber` which is the `organisationId` in the psd2certinfo class.

issue: https://github.com/ForgeCloud/ob-deploy/issues/775