### PR TITLE
40: AM session vulnerability

### DIFF
--- a/docker-compose-profiles.yml
+++ b/docker-compose-profiles.yml
@@ -348,7 +348,7 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.1-eb5282f9bc.war"
+        AM_WAR_NAME: "OpenAM-6.5.1-9f4e82458a.war"
         AMSTER_ZIP: "Amster-6.5.1.zip"
     image: openam:local
     container_name: openam

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,7 +331,7 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.1-eb5282f9bc.war"
+        AM_WAR_NAME: "OpenAM-6.5.1-9f4e82458a.war"
         AMSTER_ZIP: "Amster-6.5.1.zip"
     image: openam:local
     container_name: openam

--- a/forgerock-am/README.md
+++ b/forgerock-am/README.md
@@ -11,7 +11,7 @@ cd openbanking-reference-implementation
 gsutil rsync gs://ob-forgerock-binaries/openam-local-binaries forgerock-am/_binaries
 ```
 ### Current AM war version files
-- OpenAM-6.5.1-eb5282f9bc.war
+- OpenAM-6.5.1-9f4e82458a.war
 - Amster-6.5.1.zip
 
 ## Current Customer Patch


### PR DESCRIPTION
## changes
- Added new OpenAM war version that fix the below security issue:
   - Removed vulnerable endpoints
   - Reference: https://wikis.forgerock.org/confluence/pages/viewpage.action?spaceKey=SA&title=15+Sept+2021+-+AM+Session+Vulnerability
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/40

## Description
- In all versions of AM there is a session hijacking vulnerability that allows anyone to take control of an active session in AM. This means any AM admin console or user session can be spoofed.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* AM (local environment)


