### PR TITLE
802: Fix method level security for AS-API

### DIFF
--- a/.idea/runConfigurations/rs_api_remote.xml
+++ b/.idea/runConfigurations/rs_api_remote.xml
@@ -6,6 +6,10 @@
     <option name="HOST" value="localhost" />
     <option name="PORT" value="9094" />
     <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="9094" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
     <method v="2" />
   </configuration>
 </component>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/src/main/java/com/forgerock/openbanking/aspsp/as/AsApiSecurityConfiguration.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/src/main/java/com/forgerock/openbanking/aspsp/as/AsApiSecurityConfiguration.java
@@ -31,12 +31,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.Resource;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 import java.security.cert.X509Certificate;
 
 import static com.forgerock.openbanking.common.CertificateHelper.loadOBCertificates;
 
 @Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @Import(CookieWebSecurityConfiguration.class)
 class AsApiSecurityConfiguration {
 

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/src/main/resources/filtered/logback-spring.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/src/main/resources/filtered/logback-spring.xml
@@ -20,6 +20,7 @@
 
     <logger name="com.forgerock" level="DEBUG"/>
     <logger name="org.springframework" level="INFO"/>
+    <logger name="com.forgerock.spring.security" level="DEBUG"/>
     <logger name="org.forgerock.openbanking.commons.auth" level="TRACE"/>
 
 

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/CookieHttpSecurityHelper.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/CookieHttpSecurityHelper.java
@@ -83,18 +83,21 @@ public class CookieHttpSecurityHelper {
         MultiAuthenticationCollectorConfigurer<HttpSecurity> configurer = new MultiAuthenticationCollectorConfigurer<>();
         configurer
                 .collector(PSD2Collector.psd2Builder()
+                        .collectorName("obri-internal-PSD2-certificate collector")
                         .collectFromHeader(CertificateHeaderFormat.JWK)
                         .headerName(CLIENT_CERTIFICATE_HEADER_NAME)
                         .psd2UsernameCollector(obriInternalCertificates)
                         .psd2AuthoritiesCollector(obriInternalCertificates)
                         .build())
                 .collector(PSD2Collector.psd2Builder()
+                        .collectorName("obri-external-PSD2-certificate collector")
                         .collectFromHeader(CertificateHeaderFormat.JWK)
                         .headerName(CLIENT_CERTIFICATE_HEADER_NAME)
                         .psd2UsernameCollector(obriExternalCertificates)
                         .psd2AuthoritiesCollector(obriExternalCertificates)
                         .build())
                 .collector(StaticUserCollector.builder()
+                        .collectorName("static-user-collector")
                         .grantedAuthorities(Collections.emptySet())
                         .usernameCollector(() -> "Anonymous")
                         .build());

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/CookieWebSecurityConfiguration.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/CookieWebSecurityConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/JwtCookieAuthorityCollector.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/JwtCookieAuthorityCollector.java
@@ -47,7 +47,7 @@ public class JwtCookieAuthorityCollector implements CustomCookieCollector.Author
                 OBRIRole.ROLE_USER);
         List<String> amGroups = token.getJWTClaimsSet().getStringListClaim("group");
         if (amGroups != null && !amGroups.isEmpty()) {
-            log.trace("AM Authorities founds: {}", amGroups);
+            log.trace("AM Authorities found: {}", amGroups);
             for (String amGroup : amGroups) {
                 authorities.add(new SimpleGrantedAuthority(amGroup));
             }

--- a/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRIExternalCertificates.java
+++ b/forgerock-openbanking-common/src/main/java/com/forgerock/openbanking/common/OBRIExternalCertificates.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.forgerock.cert.Psd2CertInfo;
+import com.forgerock.cert.exception.InvalidEidasCertType;
 import com.forgerock.cert.psd2.RolesOfPsp;
 import com.forgerock.openbanking.model.OBRIRole;
 import com.forgerock.spring.security.multiauth.configurers.collectors.PSD2Collector;
@@ -70,7 +71,7 @@ public class OBRIExternalCertificates implements PSD2Collector.Psd2AuthoritiesCo
     }
 
     @Override
-    public String getUserName(X509Certificate[] certificatesChain, Psd2CertInfo psd2CertInfo) {
+    public String getUserName(X509Certificate[] certificatesChain, Psd2CertInfo psd2CertInfo) throws InvalidEidasCertType {
         if (!psd2CertInfo.isPsd2Cert()) {
             log.info("getUserName() the presented cert is not a PSD2 certificate.");
             return null;

--- a/forgerock-openbanking-gateway/src/main/java/com/forgerock/openbanking/gateway/filters/AddInteractionIdHeaderGatewayFilter.java
+++ b/forgerock-openbanking-gateway/src/main/java/com/forgerock/openbanking/gateway/filters/AddInteractionIdHeaderGatewayFilter.java
@@ -53,13 +53,15 @@ public class AddInteractionIdHeaderGatewayFilter implements GatewayFilter {
         ServerHttpRequest request = exchange.getRequest();
         String xFapiInteractionId = request.getHeaders().getFirst(X_FAPI_INTERACTION_ID_HEADER_NAME);
         if (StringUtils.isEmpty(xFapiInteractionId)) {
-            log.debug("Interaction ID is missing, generate ID '{}'", xFapiInteractionId);
+            log.debug("AddInteractionIdHeaderGatewayFilter() Interaction ID is missing, generate ID '{}'",
+                    xFapiInteractionId);
             xFapiInteractionId = UUID.randomUUID().toString();
         }
         try{
             UUID.fromString(xFapiInteractionId);
         } catch (IllegalArgumentException exception){
-            log.warn("User submitted an invalid interaction id '{}: {}'", X_FAPI_INTERACTION_ID_HEADER_NAME, xFapiInteractionId);
+            log.info("AddInteractionIdHeaderGatewayFilter() User submitted an invalid interaction id '{}: {}'",
+                    X_FAPI_INTERACTION_ID_HEADER_NAME, xFapiInteractionId);
             return Mono.error(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid header: "+X_FAPI_INTERACTION_ID_HEADER_NAME+". This header must be a RFC4122 UID"));
         }
 
@@ -69,7 +71,7 @@ public class AddInteractionIdHeaderGatewayFilter implements GatewayFilter {
         addAnalyticsEnabledTag(request);
         addFapiInteractionTag(xFapiInteractionId);
 
-        log.debug("InteractionID:{}", xFapiInteractionId);
+        log.debug("AddInteractionIdHeaderGatewayFilter() returning InteractionID:{}", xFapiInteractionId);
         exchange.getResponse().getHeaders().add(X_FAPI_INTERACTION_ID_HEADER_NAME, xFapiInteractionId);
         return chain.filter(exchange);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.4</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,14 +44,14 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-commons.version>1.2.11</ob-commons.version>
-        <ob-clients.version>1.2.11</ob-clients.version>
-        <ob-jwkms.version>1.2.10</ob-jwkms.version>
-        <ob-auth.version>1.1.10</ob-auth.version>
-        <ob-directory.version>1.5.9</ob-directory.version>
-        <ob-analytics.version>1.3.9</ob-analytics.version>
-        <ob-aspsp.version>1.5.3</ob-aspsp.version>
-	<ob-extensions.version>1.5.3</ob-extensions.version>
+        <ob-commons.version>1.2.12</ob-commons.version>
+        <ob-clients.version>1.2.12</ob-clients.version>
+        <ob-jwkms.version>1.2.11</ob-jwkms.version>
+        <ob-auth.version>1.1.11</ob-auth.version>
+        <ob-directory.version>1.5.10</ob-directory.version>
+        <ob-analytics.version>1.3.10</ob-analytics.version>
+        <ob-aspsp.version>1.5.4</ob-aspsp.version>
+	<ob-extensions.version>1.5.4</ob-extensions.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Convert Psd2Roles into OBRIRoles for method level spring security. Fix
debug output and fix ApiOBRIExternalCertificates to result in
UNKNOWN_CERTIFICATE role when presented with an OBTransport (or any non
eIDAS) certificate.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/802

