### PR TITLE
36: Now uses latest 3.1.8r5 datamodels for VRP and Funds Conf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.4</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,14 +44,14 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-commons.version>1.2.12</ob-commons.version>
-        <ob-clients.version>1.2.12</ob-clients.version>
-        <ob-jwkms.version>1.2.11</ob-jwkms.version>
-        <ob-auth.version>1.1.11</ob-auth.version>
-        <ob-directory.version>1.5.10</ob-directory.version>
-        <ob-analytics.version>1.3.10</ob-analytics.version>
-        <ob-aspsp.version>1.5.5</ob-aspsp.version>
-        <ob-extensions.version>1.5.5</ob-extensions.version>
+        <ob-commons.version>1.2.14</ob-commons.version>
+        <ob-clients.version>1.2.14</ob-clients.version>
+        <ob-jwkms.version>1.2.13</ob-jwkms.version>
+        <ob-auth.version>1.1.13</ob-auth.version>
+        <ob-directory.version>1.5.12</ob-directory.version>
+        <ob-analytics.version>1.3.12</ob-analytics.version>
+        <ob-aspsp.version>1.5.6</ob-aspsp.version>
+        <ob-extensions.version>1.5.6</ob-extensions.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
While the VRP controllers are not yet in place, the following issue alluded to problems with the swagger generation;
https://github.com/OpenBankingToolkit/openbanking-aspsp/pull/421

A newer version (3.1.8r5) of the swagger files are available and I have regenerated the datamodels, and the VRP controllers from this swagger spec. 

This PR only adds the new model changes to the openbanking-uk-datamodel and changes all components to use the new models. ASPSP required some changes to convert the new Funds Conformation classes to FR classes for storage. 

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/36