### PR TITLE
Support Open Banking Read/Write API 3.1.10

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/main/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsApiController.java
@@ -67,7 +67,8 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
 @Controller("CSVFilePaymentConsentsApiV3.1.3")
-@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp","/open-banking/v3.1.6/pisp", "/open-banking/v3.1.7/pisp", "/open-banking/v3.1.8/pisp", "/open-banking/v3.1.9/pisp"})
+@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp","/open-banking/v3.1.6/pisp",
+        "/open-banking/v3.1.7/pisp", "/open-banking/v3.1.8/pisp", "/open-banking/v3.1.9/pisp", "/open-banking/v3.1.10/pisp"})
 @Slf4j
 public class CSVFilePaymentConsentsApiController {
 

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_10/CSVFilePaymentConsentsRsApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/src/test/java/com/forgerock/openbanking/aspsp/rs/ext/lbg/file/payment/csv/test/v3_1_10/CSVFilePaymentConsentsRsApiControllerIT.java
@@ -1,0 +1,334 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.test.v3_1_10;
+
+import com.forgerock.openbanking.am.services.AMResourceServerService;
+import com.forgerock.openbanking.aspsp.rs.ForgerockOpenbankingRsApiApplication;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVFilePaymentFactory;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVFilePaymentType;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVCreditIndicatorRow;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVDebitIndicatorSection;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
+import com.forgerock.openbanking.aspsp.rs.wrappper.endpoints.FilePaymentsApiEndpointWrapper;
+import com.forgerock.openbanking.common.conf.RSConfiguration;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
+import com.forgerock.openbanking.common.services.store.RsStoreGateway;
+import com.forgerock.openbanking.common.services.store.payment.FilePaymentService;
+import com.forgerock.openbanking.common.services.store.tpp.TppStoreServiceImpl;
+import com.forgerock.openbanking.constants.OIDCConstants;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.integration.test.support.SpringSecForTest;
+import com.forgerock.openbanking.jwt.services.CryptoApiClient;
+import com.forgerock.openbanking.model.OBRIRole;
+import com.github.jsonzou.jmockdata.JMockData;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.val;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.org.openbanking.OBHeaders;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
+import static com.forgerock.openbanking.integration.test.support.JWT.jws;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(classes = {ForgerockOpenbankingRsApiApplication.class})
+public class CSVFilePaymentConsentsRsApiControllerIT {
+
+    private final static String _url = "/open-banking/v3.1.10/pisp/file-payment-consents/{ConsentId}/file";
+    private CSVFilePayment file;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    private SpringSecForTest springSecForTest;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @MockBean(name = "amResourceServerService") // Required to avoid Spring auto-wiring exception
+    private AMResourceServerService amResourceServerService;
+
+    // required to mock verifyMatlsFromAccessToken
+    @MockBean
+    private FilePaymentsApiEndpointWrapper filePaymentsApiEndpointWrapper;
+
+    @MockBean(name="tppStoreService") // required to avoid connection rs-store
+    private TppStoreServiceImpl tppStoreService;
+
+    @MockBean(name = "cryptoApiClient") // Required to avoid Spring auto-wiring exception
+    private CryptoApiClient cryptoApiClient;
+
+    @MockBean
+    private RsStoreGateway rsStoreGateway;
+
+    @MockBean
+    private FilePaymentService filePaymentService;
+
+    @Autowired
+    private RSConfiguration rsConfiguration;
+
+    @LocalServerPort
+    private int port;
+
+    @Before
+    public void setUp() {
+        Exception error = catchThrowableOfType(
+                () -> setFile(),
+                Exception.class
+        );
+        assertThat(error).isNull();
+        assertThat(file).isNotNull();
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+    }
+
+    /**
+     * Integration BACS File payment test <br/>
+     * Expected HTTP 201 create code
+     * @throws Exception
+     */
+    @Test
+    public void test_BULK_BACS_filePayment_upload() throws Exception {
+
+        // given
+        String jws = jws("payments", OIDCConstants.GrantType.CLIENT_CREDENTIAL);
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
+        doNothing().when(filePaymentsApiEndpointWrapper).verifyMatlsFromAccessToken();
+        String fileConsentId = UUID.randomUUID().toString();
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+
+        given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
+        given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
+
+        // then
+        MvcResult result = mockMvc.perform(
+                MockMvcRequestBuilders
+                        .post("https://rs-api:" + port + _url, fileConsentId)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
+                        .contentType("text/plain")
+                        .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
+                        .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                        .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                        .header("x-ob-client-id", "pispId123")
+                        .content(file.toString()))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Assertions.assertThat(result.getResponse().getStatus()).isEqualTo(201);
+    }
+
+    /**
+     * Integration Batch File payment test <br/>
+     * Expected HTTP 201 create code
+     * @throws Exception
+     */
+    @Test
+    public void test_BATCH_FPS_filePayment_upload() throws Exception {
+
+        // given
+        String jws = jws("payments", OIDCConstants.GrantType.CLIENT_CREDENTIAL);
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        given(amResourceServerService.verifyAccessToken("Bearer " + jws)).willReturn(SignedJWT.parse(jws));
+        doNothing().when(filePaymentsApiEndpointWrapper).verifyMatlsFromAccessToken();
+        String fileConsentId = UUID.randomUUID().toString();
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId,file.toString(), consentRequest);
+
+        given(rsStoreGateway.toRsStore(any(), any(), any(), any(), any())).willReturn(ResponseEntity.status(HttpStatus.CREATED).body(existingConsent));
+        given(filePaymentService.getPayment(fileConsentId)).willReturn(existingConsent);
+
+        // then
+        MvcResult result = mockMvc.perform(
+                MockMvcRequestBuilders
+                        .post("https://rs-api:" + port + _url, fileConsentId)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
+                        .contentType("text/plain")
+                        .header(OBHeaders.AUTHORIZATION, "Bearer " + jws)
+                        .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                        .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                        .header("x-ob-client-id", "pispId123")
+                        .content(file.toString()))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Assertions.assertThat(result.getResponse().getStatus()).isEqualTo(201);
+    }
+
+    /**
+     * Create the consent request object
+     * @param csvFileContent
+     * @param fileType
+     * @return
+     */
+    private static final OBWriteFileConsent3 mockConsent(String csvFileContent, String fileType){
+        OBWriteFileConsent3 consentRequest = JMockData.mock(OBWriteFileConsent3.class);
+        consentRequest.getData().getInitiation().fileHash(computeSHA256FullHash(csvFileContent));
+        consentRequest.getData().getInitiation().fileReference("FileRef001");
+        consentRequest.getData().getInitiation().fileType(fileType);
+        consentRequest.getData().getInitiation().numberOfTransactions("1");
+        consentRequest.getData().getInitiation().controlSum(new BigDecimal("10.10"));
+        consentRequest.getData().getInitiation().localInstrument("Local-instrument");
+        consentRequest.getData().getInitiation().supplementaryData(new OBSupplementaryData1());
+        return consentRequest;
+    }
+
+    /**
+     * Create the file payment consent object
+     * @param fileConsentId
+     * @param csvFileContent
+     * @param consentRequest
+     * @return
+     */
+    private static final FRFileConsent mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent frFileConsent = JMockData.mock(FRFileConsent.class);
+        frFileConsent.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent.setId(fileConsentId);
+        frFileConsent.setFileContent(csvFileContent);
+        frFileConsent.setPayments(Collections.emptyList());
+        frFileConsent.setWriteFileConsent(toFRWriteFileConsent(consentRequest));
+        return frFileConsent;
+    }
+
+    /**
+     * Create a instance of CSVFilePayment
+     * or reset the fields values to reuse it on every test
+     *
+     * @throws OBErrorException
+     */
+    @Ignore
+    private void setFile() throws OBErrorException {
+        if (file == null) {
+            file = CSVFilePaymentFactory.create(CSVFilePaymentType.UK_LBG_FPS_BATCH_V10);
+        }
+        file.setHeaderIndicator(
+                CSVHeaderIndicatorSection.builder()
+                        .headerIndicator(CSVHeaderIndicatorSection.HEADER_IND_EXPECTED)
+                        .fileCreationDate(file.getDateTimeFormatter().format(LocalDate.now()))
+                        .uniqueId("ID001")
+                        .numCredits(1)
+                        .valueCreditsSum(new BigDecimal(10.10).setScale(2, RoundingMode.CEILING))
+                        .build()
+        );
+
+        file.setDebitIndicator(
+                CSVDebitIndicatorSection.builder()
+                        .debitIndicator(CSVDebitIndicatorSection.DEBIT_IND_EXPECTED)
+                        .paymentDate(file.getDateTimeFormatter().format(LocalDate.now().plusDays(2)))
+                        .batchReference("Payments")
+                        .debitAccountDetails("301775-12345678")
+                        .build()
+        );
+
+        List row = new ArrayList<CSVCreditIndicatorRow>();
+        row.add(
+                CSVCreditIndicatorRow.builder()
+                        .creditIndicator(CSVCreditIndicatorRow.CREDIT_IND_EXPECTED)
+                        .recipientName("Beneficiary name")
+                        .accNumber("12345678")
+                        .recipientSortCode("301763")
+                        .reference("Beneficiary ref.")
+                        .debitAmount(new BigDecimal(10.10).setScale(2, RoundingMode.CEILING))
+                        .paymentASAP(CSVValidation.PAYMENT_ASAP_VALUES[0])
+                        .paymentDate("")
+                        .eToEReference("EtoEReference")
+                        .build()
+        );
+
+        file.setCreditIndicatorRows(row);
+    }
+
+    /**
+     * Get the file content like a string
+     * @param filePath
+     * @return String file content
+     * @throws IOException
+     */
+    @Ignore
+    private static final String getContent(final String filePath) throws IOException {
+        return Files.readString(Paths.get(filePath), StandardCharsets.UTF_8);
+    }
+
+    @Ignore
+    private static final String computeSHA256FullHash(final String content) {
+        try {
+            val digest = MessageDigest.getInstance("SHA-256");
+            val hash = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unknown algorithm for file hash: SHA-256");
+        }
+    }
+}

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/main/java/com/forgerock/openbanking/aspsp/rs/store/ext/lbg/file/payment/csv/api/v3_1_3/CSVFilePaymentConsentsRsStoreApiController.java
@@ -72,7 +72,8 @@ import static com.forgerock.openbanking.constants.OpenBankingConstants.HTTP_DATE
 
 @Api(value = "csv-file-payment-consents", description = "the CSV file-payment-consents API")
 @Controller("CSVFilePaymentConsentsApiV3.1.3")
-@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp","/open-banking/v3.1.6/pisp", "/open-banking/v3.1.7/pisp", "/open-banking/v3.1.8/pisp", "/open-banking/v3.1.9/pisp"})
+@RequestMapping({"/open-banking/v3.1.3/pisp","/open-banking/v3.1.4/pisp","/open-banking/v3.1.5/pisp","/open-banking/v3.1.6/pisp",
+        "/open-banking/v3.1.7/pisp", "/open-banking/v3.1.8/pisp", "/open-banking/v3.1.9/pisp", "/open-banking/v3.1.10/pisp"})
 @Slf4j
 public class CSVFilePaymentConsentsRsStoreApiController {
 

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_10/CSVFilePaymentConsentsRsStoreApiControllerIT.java
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/src/test/java/com/forgerock/openbanking/extensions/lbg/test/v3_1_10/CSVFilePaymentConsentsRsStoreApiControllerIT.java
@@ -1,0 +1,438 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.extensions.lbg.test.v3_1_10;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVFilePaymentFactory;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.factory.CSVFilePaymentType;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVCreditIndicatorRow;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVDebitIndicatorSection;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVFilePayment;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.model.CSVHeaderIndicatorSection;
+import com.forgerock.openbanking.aspsp.rs.ext.lbg.file.payment.csv.validation.CSVValidation;
+import com.forgerock.openbanking.aspsp.rs.store.ForgerockOpenbankingRsStoreApplication;
+import com.forgerock.openbanking.aspsp.rs.store.repository.payments.FileConsentRepository;
+import com.forgerock.openbanking.common.conf.RSConfiguration;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.ConsentStatusCode;
+import com.forgerock.openbanking.common.model.openbanking.persistence.payment.FRFileConsent;
+import com.forgerock.openbanking.common.model.version.OBVersion;
+import com.forgerock.openbanking.exceptions.OBErrorException;
+import com.forgerock.openbanking.extensions.lbg.test.MockTppHelper;
+import com.forgerock.openbanking.integration.test.support.SpringSecForTest;
+import com.forgerock.openbanking.model.OBRIRole;
+import com.forgerock.openbanking.repositories.TppRepository;
+import com.github.jsonzou.jmockdata.JMockData;
+import kong.unirest.HttpResponse;
+import kong.unirest.JacksonObjectMapper;
+import kong.unirest.JsonNode;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.json.JSONArray;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.org.openbanking.OBHeaders;
+import uk.org.openbanking.datamodel.payment.OBExternalConsentStatus2Code;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse2;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileConsent;
+import static com.forgerock.openbanking.common.services.openbanking.converter.payment.FRWriteFileConsentConverter.toFRWriteFileDataInitiation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+@Slf4j
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(classes = ForgerockOpenbankingRsStoreApplication.class)
+public class CSVFilePaymentConsentsRsStoreApiControllerIT {
+
+    private static final String _URL = "/open-banking/v3.1.10/pisp/file-payment-consents/";
+    private CSVFilePayment file;
+
+    @LocalServerPort
+    private int port;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private RSConfiguration rsConfiguration;
+    @Autowired
+    private FileConsentRepository repository;
+    @MockBean
+    private TppRepository tppRepository;
+
+    @Autowired
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    private SpringSecForTest springSecForTest;
+
+    @Before
+    public void setUp() {
+        Exception error = catchThrowableOfType(
+                () -> setFile(),
+                Exception.class
+        );
+        assertThat(error).isNull();
+        assertThat(file).isNotNull();
+        Unirest.config().setObjectMapper(new JacksonObjectMapper(objectMapper)).verifySsl(false);
+    }
+
+    /**
+     * Expected http 201 code
+     * @throws UnirestException
+     */
+    @Test
+    public void testCreateFileConsentAllFields() throws UnirestException {
+        // Given
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+
+        // When
+        HttpResponse<OBWriteFileConsentResponse2> response = Unirest.post("https://rs-store:" + port + _URL)
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, "x-jws-signature")
+                .header(CONTENT_TYPE, "application/json")
+                .header(ACCEPT, "application/json")
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body(consentRequest)
+                .asObject(OBWriteFileConsentResponse2.class);
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(201);
+        OBWriteFileConsentResponse2 consentResponse = response.getBody();
+        FRFileConsent consent = repository.findById(consentResponse.getData().getConsentId()).get();
+        assertThat(consent.getPispName()).isEqualTo(MockTppHelper.MOCK_PISP_NAME);
+        assertThat(consent.getPispId()).isEqualTo(MockTppHelper.MOCK_PISP_ID);
+        assertThat(consent.getId()).isEqualTo(consentResponse.getData().getConsentId());
+        assertThat(consent.getInitiation()).isEqualTo(toFRWriteFileDataInitiation(consentResponse.getData().getInitiation()));
+        assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(consentResponse.getData().getStatus());
+        assertThat(consent.getObVersion()).isEqualTo(OBVersion.v3_1_10);
+    }
+
+    /**
+     * Expected http 200 code
+     * @throws UnirestException
+     * @throws IOException
+     */
+    @Test
+    public void testCreateFilePaymentConsentsFPSFile() throws UnirestException, IOException {
+        // Given
+        String fileConsentId = UUID.randomUUID().toString();
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_FPS_BATCH_V10.getFileType());
+
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+
+        repository.save(existingConsent);
+
+        // When
+        HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body(file.toString())
+                .asString();
+
+        // Then
+        log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
+        assertThat(response.getStatus()).isEqualTo(200);
+        FRFileConsent consent = repository.findById(fileConsentId).get();
+        assertThat(consent.getId()).isEqualTo(fileConsentId);
+        assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
+        assertThat(consent.getFileContent()).isEqualTo(file.toString());
+    }
+
+    /**
+     * Expected http 200 code
+     * @throws UnirestException
+     * @throws IOException
+     */
+    @Test
+    public void testCreateFilePaymentConsentsBACSFile() throws UnirestException, IOException {
+        // Given
+        String fileConsentId = UUID.randomUUID().toString();
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+
+        repository.save(existingConsent);
+
+        // When
+        HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body(file.toString())
+                .asString();
+
+        // Then
+        log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
+        assertThat(response.getStatus()).isEqualTo(200);
+        FRFileConsent consent = repository.findById(fileConsentId).get();
+        assertThat(consent.getId()).isEqualTo(fileConsentId);
+        assertThat(consent.getStatus().toOBExternalConsentStatus2Code()).isEqualTo(OBExternalConsentStatus2Code.AWAITINGAUTHORISATION);
+        assertThat(consent.getFileContent()).isEqualTo(file.toString());
+    }
+
+    /**
+     * Expected http 400 error code<br/>
+     * @throws UnirestException
+     */
+    @Test
+    public void testCreateFilePaymentFileNotFound() throws UnirestException {
+        // Given
+        String fileConsentId = UUID.randomUUID().toString();
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+        HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body("csvFileContent")
+                .asJson();
+
+        // then
+        JsonNode jsonResponseBody = (JsonNode) response.getBody();
+        JSONArray jsonErrors = (JSONArray) jsonResponseBody.getObject().get("Errors");
+        log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(jsonResponseBody.getObject().get("Code")).isEqualTo("OBRI.Request.Invalid");
+        assertThat(jsonErrors.optJSONObject(0).get("ErrorCode")).isEqualTo("OBRI.Payment.NotFound");
+    }
+
+    /**
+     * Expected http 415 error code<br/>
+     * @throws UnirestException
+     */
+    @Test
+    public void testCreateFilePayment_Unsupported_MediaType() throws UnirestException {
+        // Given
+        String fileConsentId = UUID.randomUUID().toString();
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+        HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                .header(CONTENT_TYPE, "CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType()")
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body("csvFileContent")
+                .asJson();
+
+        // then
+        JsonNode jsonResponseBody = (JsonNode) response.getBody();
+        JSONArray jsonErrors = (JSONArray) jsonResponseBody.getObject().get("Errors");
+        log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
+        assertThat(response.getStatus()).isEqualTo(415);
+        assertThat(jsonResponseBody.getObject().get("Code")).isEqualTo("OBRI.Request.Invalid");
+        assertThat(jsonErrors.optJSONObject(0).get("ErrorCode")).isEqualTo("OBRI.Request.MediaType.NotSupported");
+    }
+
+    /**
+     * Expected http 400 error code<br/>
+     * @throws UnirestException
+     */
+    @Test
+    public void testCreateFilePayment_Invalid_format() throws UnirestException {
+        // Given
+        String fileConsentId = UUID.randomUUID().toString();
+        springSecForTest.mockAuthCollector.mockAuthorities(OBRIRole.ROLE_PISP);
+        MockTppHelper.setupMockTpp(tppRepository);
+
+        OBWriteFileConsent3 consentRequest = mockConsent(file.toString(), CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getFileType());
+
+        FRFileConsent existingConsent = mockFileConsent(fileConsentId, "", consentRequest);
+
+        repository.save(existingConsent);
+
+        HttpResponse response = Unirest.post("https://rs-store:" + port + _URL + fileConsentId + "/file")
+                .accept(MediaType.APPLICATION_JSON_UTF8.toString())
+                .header(OBHeaders.AUTHORIZATION, "token")
+                .header(OBHeaders.X_IDEMPOTENCY_KEY, UUID.randomUUID().toString())
+                .header(OBHeaders.X_JWS_SIGNATURE, UUID.randomUUID().toString())
+                .header(CONTENT_TYPE, CSVFilePaymentType.UK_LBG_BACS_BULK_V10.getContentType())
+                .header("x-ob-client-id", MockTppHelper.MOCK_CLIENT_ID)
+                .body("csvFileContent")
+                .asJson();
+
+        // then
+        JsonNode jsonResponseBody = (JsonNode) response.getBody();
+        JSONArray jsonErrors = (JSONArray) jsonResponseBody.getObject().get("Errors");
+        log.debug("{}. Response: {}", response.getStatus(), response.getBody() != null ? response.getBody() : response.getParsingError());
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThat(jsonResponseBody.getObject().get("Code")).isEqualTo("OBRI.Request.Invalid");
+        assertThat(jsonErrors.optJSONObject(0).get("ErrorCode")).isEqualTo("UK.OBIE.Resource.InvalidFormat");
+    }
+
+    /**
+     * Create the consent request object
+     * @param fileType
+     * @return
+     */
+    @Ignore
+    private static final OBWriteFileConsent3 mockConsent(String fileContent, String fileType){
+        OBWriteFileConsent3 consentRequest = JMockData.mock(OBWriteFileConsent3.class);
+        consentRequest.getData().getInitiation().fileHash(computeSHA256FullHash(fileContent));
+        consentRequest.getData().getInitiation().fileReference("ref-001");
+        consentRequest.getData().getInitiation().fileType(fileType);
+        consentRequest.getData().getInitiation().numberOfTransactions("1");
+        consentRequest.getData().getInitiation().controlSum(new BigDecimal("10.00"));
+        consentRequest.getData().getInitiation().localInstrument("Local-instrument");
+        consentRequest.getData().getInitiation().supplementaryData(new OBSupplementaryData1());
+        return consentRequest;
+    }
+
+    /**
+     * Create the file payment consent object
+     * @param fileConsentId
+     * @param csvFileContent
+     * @param consentRequest
+     * @return
+     */
+    @Ignore
+    private static final FRFileConsent mockFileConsent(String fileConsentId, String csvFileContent, OBWriteFileConsent3 consentRequest){
+        FRFileConsent frFileConsent2 = JMockData.mock(FRFileConsent.class);
+        frFileConsent2.setStatus(ConsentStatusCode.AWAITINGAUTHORISATION);
+        frFileConsent2.setId(fileConsentId);
+        frFileConsent2.setFileContent(csvFileContent);
+        frFileConsent2.setPayments(Collections.emptyList());
+        frFileConsent2.setWriteFileConsent(toFRWriteFileConsent(consentRequest));
+        return frFileConsent2;
+    }
+
+    @Ignore
+    private static final String computeSHA256FullHash(final String content) {
+        try {
+            val digest = MessageDigest.getInstance("SHA-256");
+            val hash = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unknown algorithm for file hash: SHA-256");
+        }
+
+    }
+
+    /**
+     * Create a instance of CSVFilePayment
+     * or reset the fields values to reuse it on every test
+     *
+     * @throws OBErrorException
+     */
+    @Ignore
+    private void setFile() throws OBErrorException {
+        if (file == null) {
+            file = CSVFilePaymentFactory.create(CSVFilePaymentType.UK_LBG_FPS_BATCH_V10);
+        }
+        file.setHeaderIndicator(
+                CSVHeaderIndicatorSection.builder()
+                        .headerIndicator(CSVHeaderIndicatorSection.HEADER_IND_EXPECTED)
+                        .fileCreationDate(file.getDateTimeFormatter().format(LocalDate.now()))
+                        .uniqueId("ID001")
+                        .numCredits(1)
+                        .valueCreditsSum(new BigDecimal(10.10).setScale(2, RoundingMode.CEILING))
+                        .build()
+        );
+
+        file.setDebitIndicator(
+                CSVDebitIndicatorSection.builder()
+                        .debitIndicator(CSVDebitIndicatorSection.DEBIT_IND_EXPECTED)
+                        .paymentDate(file.getDateTimeFormatter().format(LocalDate.now().plusDays(2)))
+                        .batchReference("Payments")
+                        .debitAccountDetails("301775-12345678")
+                        .build()
+        );
+
+        List row = new ArrayList<CSVCreditIndicatorRow>();
+        row.add(
+                CSVCreditIndicatorRow.builder()
+                        .creditIndicator(CSVCreditIndicatorRow.CREDIT_IND_EXPECTED)
+                        .recipientName("Beneficiary name")
+                        .accNumber("12345678")
+                        .recipientSortCode("301763")
+                        .reference("Beneficiary ref.")
+                        .debitAmount(new BigDecimal(10.10).setScale(2, RoundingMode.CEILING))
+                        .paymentASAP(CSVValidation.PAYMENT_ASAP_VALUES[0])
+                        .paymentDate("")
+                        .eToEReference("EtoEReference")
+                        .build()
+        );
+
+        file.setCreditIndicatorRows(row);
+    }
+
+    /**
+     * Get the file content like a string
+     * @param filePath
+     * @return String file content
+     * @throws IOException
+     */
+    @Ignore
+    static final String getContent(String filePath) throws IOException {
+        return Files.readString(Paths.get(filePath), StandardCharsets.UTF_8);
+    }
+}

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -101,7 +101,7 @@ rs-discovery:
   hostname: matls.rs.aspsp.${dns.hosts.root}
   base-url: https://${rs-discovery.hostname}
   read-write-api:
-    version: 3.1.9 # new Feature: Vrp payment support
+    version: 3.1.10
   apis:
     payments:
       v_1_1:
@@ -545,6 +545,48 @@ rs-discovery:
         getFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/file-payments/{FilePaymentId}
         getFilePaymentReport: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/file-payments/{ConsentId}/report-file
         getFilePaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/file-payments/{FilePaymentId}/payment-details
+      v_3_1_10:
+        createDomesticPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payment-consents
+        getDomesticPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payment-consents/{ConsentId}
+        getDomesticPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation
+        createDomesticPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payments
+        getDomesticPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payments/{DomesticPaymentId}
+        getDomesticPaymentsDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-payments/{DomesticPaymentId}/payment-details
+        createDomesticScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-scheduled-payment-consents
+        getDomesticScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-scheduled-payment-consents/{ConsentId}
+        createDomesticScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-scheduled-payments
+        getDomesticScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}
+        getDomesticScheduledPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}/payment-details
+        createDomesticStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-standing-order-consents
+        getDomesticStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-standing-order-consents/{ConsentId}
+        createDomesticStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-standing-orders
+        getDomesticStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-standing-orders/{DomesticStandingOrderId}
+        getDomesticStandingOrderPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-standing-orders/{DomesticStandingOrderId}/payment-details
+        createInternationalPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payment-consents
+        getInternationalPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payment-consents/{ConsentId}
+        getInternationalPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payment-consents/{ConsentId}/funds-confirmation
+        createInternationalPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payments
+        getInternationalPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payments/{InternationalPaymentId}
+        getInternationalPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-payments/{InternationalPaymentId}/payment-details
+        createInternationalScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payment-consents
+        getInternationalScheduledPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payment-consents/{ConsentId}
+        getInternationalScheduledPaymentConsentsConsentIdFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation
+        createInternationalScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payments
+        getInternationalScheduledPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}
+        getInternationalScheduledPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}/payment-details
+        createInternationalStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-standing-order-consents
+        getInternationalStandingOrderConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-standing-order-consents/{ConsentId}
+        createInternationalStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-standing-orders
+        getInternationalStandingOrder: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-standing-orders/{InternationalStandingOrderId}
+        getInternationalStandingOrderPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}/payment-details
+        createFilePaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payment-consents
+        getFilePaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payment-consents/{ConsentId}
+        createFilePaymentFile: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payment-consents/{ConsentId}/file
+        getFilePaymentFile: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payment-consents/{ConsentId}/file
+        createFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payments
+        getFilePayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payments/{FilePaymentId}
+        getFilePaymentReport: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payments/{ConsentId}/report-file
+        getFilePaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/file-payments/{FilePaymentId}/payment-details
     accounts:
       v_1_1:
         createAccountRequest: ${rs-discovery.base-url}/open-banking/v1.1/account-requests
@@ -949,6 +991,36 @@ rs-discovery:
         getParty: ${rs-discovery.base-url}/open-banking/v3.1.9/aisp/party
         getScheduledPayments: ${rs-discovery.base-url}/open-banking/v3.1.9/aisp/scheduled-payments
         getStatements: ${rs-discovery.base-url}/open-banking/v3.1.9/aisp/statements
+      v_3_1_10:
+        createAccountAccessConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/account-access-consents
+        getAccountAccessConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/account-access-consents/{ConsentId}
+        deleteAccountAccessConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/account-access-consents/{ConsentId}
+        getAccount: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}
+        getAccountTransactions: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/transactions
+        getAccountBeneficiaries: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/beneficiaries
+        getAccountBalances: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/balances
+        getAccountDirectDebits: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/direct-debits
+        getAccountStandingOrders: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/standing-orders
+        getAccountProduct: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/product
+        getAccounts: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts
+        getStandingOrders: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/standing-orders
+        getDirectDebits: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/direct-debits
+        getBeneficiaries: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/beneficiaries
+        getTransactions: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/transactions
+        getBalances: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/balances
+        getProducts: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/products
+        getAccountOffers: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/offers
+        getAccountParty: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/party
+        getAccountParties: ${rs-discovery.base-url}/open-banking/v3.1.10/accounts/{AccountId}/parties
+        getAccountScheduledPayments: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/scheduled-payments
+        getAccountStatements: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/statements
+        getAccountStatement: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/statements/{StatementId}
+        getAccountStatementFile: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/statements/{StatementId}/file
+        getAccountStatementTransactions: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/accounts/{AccountId}/statements/{StatementId}/transactions
+        getOffers: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/offers
+        getParty: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/party
+        getScheduledPayments: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/scheduled-payments
+        getStatements: ${rs-discovery.base-url}/open-banking/v3.1.10/aisp/statements
     fundsConfirmations:
       v_3_0:
         createFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.0/cbpii/funds-confirmation-consents
@@ -1005,6 +1077,11 @@ rs-discovery:
         getFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.1.9/cbpii/funds-confirmation-consents/{ConsentId}
         createFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.9/cbpii/funds-confirmations
         deleteFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.1.9/cbpii/funds-confirmations-consent
+      v_3_1_10:
+        createFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/cbpii/funds-confirmation-consents
+        getFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/cbpii/funds-confirmation-consents/{ConsentId}
+        createFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.10/cbpii/funds-confirmations
+        deleteFundsConfirmationConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/cbpii/funds-confirmations-consent
     eventNotifications:
       v_3_0:
         createCallbackUrl: ${rs-discovery.base-url}/open-banking/v3.0/callback-urls
@@ -1093,6 +1170,15 @@ rs-discovery:
         getEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.9/event-subscriptions
         amendEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.9/event-subscriptions/{EventSubscriptionId}
         deleteEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.9/event-subscriptions/{EventSubscriptionId}
+      v_3_1_10:
+        createCallbackUrl: ${rs-discovery.base-url}/open-banking/v3.1.10/callback-urls
+        getCallbackUrls: ${rs-discovery.base-url}/open-banking/v3.1.10/callback-urls
+        amendCallbackUrl: ${rs-discovery.base-url}/open-banking/v3.1.10/callback-urls/{CallbackUrlId}
+        deleteCallbackUrl: ${rs-discovery.base-url}/open-banking/v3.1.10/callback-urls/{CallbackUrlId}
+        createEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.10/event-subscriptions
+        getEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.10/event-subscriptions
+        amendEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.10/event-subscriptions/{EventSubscriptionId}
+        deleteEventSubscription: ${rs-discovery.base-url}/open-banking/v3.1.10/event-subscriptions/{EventSubscriptionId}
     vrpPayments:
       v_3_1_8:
         createDomesticVrpPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.8/pisp/domestic-vrp-consents
@@ -1110,6 +1196,14 @@ rs-discovery:
         createDomesticVrpPayment: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/domestic-vrps
         getDomesticVrpPayment: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/domestic-vrps/{DomesticVRPId}
         getDomesticVrpPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.9/pisp/domestic-vrps/{DomesticVRPId}/payment-details
+      v_3_1_10:
+        createDomesticVrpPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrp-consents
+        getDomesticVrpPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrp-consents/{ConsentId}
+        deleteDomesticVrpPaymentConsent: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrp-consents/{ConsentId}
+        getDomesticVrpPaymentFundsConfirmation: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrp-consents/{ConsentId}/funds-confirmation
+        createDomesticVrpPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrps
+        getDomesticVrpPayment: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrps/{DomesticVRPId}
+        getDomesticVrpPaymentDetails: ${rs-discovery.base-url}/open-banking/v3.1.10/pisp/domestic-vrps/{DomesticVRPId}/payment-details
     customerInfo:
       v_1_0:
         getCustomerInfo: ${rs-discovery.base-url}/customer-info/v1.0/info

--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -90,6 +90,12 @@ rs:
   financial_id: 0015800001041REAAY
   jwks_uri: https://matls.rs.aspsp.${dns.hosts.root}:${rcs.port}/api/jwk/jwk_uri
 
+  # Switch to enable extended validation to VRP, see: https://github.com/ForgeCloud/ob-deploy/issues/883
+  vrp:
+    extended:
+      validation:
+        enable: true
+
 rs-simulator:
   port: 443
   internal-port: 8443

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>4.7.1-SNAPSHOT</version>
+         <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.7.1-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>4.7.1-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,13 +44,13 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-commons.version>1.4.1</ob-commons.version>
-        <ob-clients.version>1.4.1</ob-clients.version>
-        <ob-jwkms.version>1.4.1</ob-jwkms.version>
-        <ob-auth.version>1.4.1</ob-auth.version>
+        <ob-commons.version>1.5.0</ob-commons.version>
+        <ob-clients.version>1.5.0</ob-clients.version>
+        <ob-jwkms.version>1.5.0</ob-jwkms.version>
+        <ob-auth.version>1.5.0</ob-auth.version>
         <ob-directory.version>1.7.1</ob-directory.version>
         <ob-analytics.version>1.5.1</ob-analytics.version>
-        <ob-aspsp.version>2.0.1</ob-aspsp.version>
+        <ob-aspsp.version>2.1.0</ob-aspsp.version>
         <ob-extensions.version>1.8.1</ob-extensions.version>
     </properties>
 


### PR DESCRIPTION
Support Open Banking Read/Write API 3.1.10

- Bump aspsp to 2.1.0
- Bump parent to 2.1.0
- Bump common to 1.5.0
- Bump clients to 1.5.0
- Bump jwkms to 1.5.0
- Bump auth to 1.5.0

https://github.com/ForgeCloud/ob-deploy/issues/872