### PR TITLE
925: OB AM version patched upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ mongodata/
 mongobackups/
 /release.properties
 *.releaseBackup
+/.java-version

--- a/docker-compose-profiles.yml
+++ b/docker-compose-profiles.yml
@@ -350,8 +350,8 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.1-9f4e82458a.war"
-        AMSTER_ZIP: "Amster-6.5.1.zip"
+        AM_WAR_NAME: "OpenAM-6.5.5-a7dd57885e7.war"
+        AMSTER_ZIP: "Amster-6.5.5-a7dd57885e7.zip"
     image: openam:local
     container_name: openam
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,8 +332,8 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.1-9f4e82458a.war"
-        AMSTER_ZIP: "Amster-6.5.1.zip"
+        AM_WAR_NAME: "OpenAM-6.5.5-a7dd57885e7.war"
+        AMSTER_ZIP: "Amster-6.5.5-a7dd57885e7.zip"
     image: openam:local
     container_name: openam
     ports:

--- a/forgerock-am/Dockerfile
+++ b/forgerock-am/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y unzip && \
     mkdir -p /var/tmp/openam && \
     unzip -q /am.war -d /var/tmp/openam && \
-    if ! grep -q "com.iplanet.am.buildVersion=ForgeRock Access Management 6.5.1" /var/tmp/openam/WEB-INF/classes/serverdefaults.properties; then \
-    echo "ERROR: Provided war file is not AM version 6.5.1" && \
+    if ! grep -q "com.iplanet.am.buildVersion=ForgeRock Access Management 6.5.5" /var/tmp/openam/WEB-INF/classes/serverdefaults.properties; then \
+    echo "ERROR: Provided war file is not AM version 6.5.5" && \
     echo "VERSION FOUND: $(grep 'com.iplanet.am.buildVersion=' /var/tmp/openam/WEB-INF/classes/serverdefaults.properties)" && \
     exit 10; \
     fi && \

--- a/forgerock-am/README.md
+++ b/forgerock-am/README.md
@@ -11,14 +11,18 @@ cd openbanking-reference-implementation
 gsutil rsync gs://ob-forgerock-binaries/openam-local-binaries forgerock-am/_binaries
 ```
 ### Current AM war version files
-- OpenAM-6.5.1-9f4e82458a.war
-- Amster-6.5.1.zip
+Source: [patches/6.5.5.1/openbanking](https://stash.forgerock.org/projects/OPENAM/repos/openam-customers/browse?at=refs%2Fheads%2Fpatches%2F6.5.5.1%2Fopenbanking)
+- OpenAM-6.5.5-a7dd57885e7.war
+- Amster-6.5.5-a7dd57885e7.zip
 
-## Current Customer Patch
-> The customer patch is not needed anymore because 
-> the AM.war builds for Open Banking is from the customer branch with all patches integrated
-- openbanking-1-2-tpatch.zip
+> The AM.war builds for Open Banking is from the customer branch with all patches integrated
 
+**How to when AM version changed**
+- Update ./forgerock-am/amster/config/global/Platform.json
+- Update ./forgerock-am/Dockerfile (`com.iplanet.am.buildVersion` value)
+- Update ./forgerock-am/README.md file
+- Update kube configuration [ob-kube-am-config am](https://github.com/ForgeCloud/ob-kube-am-config/blob/master/docker/am/Dockerfile)
+- Update kube configuration [ob-kube-am-config amster](https://github.com/ForgeCloud/ob-kube-am-config/blob/master/docker/amster/Dockerfile)
 ## Docker compose
 Edit `docker-compose.yml` if necessary to change the arguments:
 - **AM_WAR_NAME**: "*OpenAM-X.X.X.war*"

--- a/forgerock-am/amster/config/global/Platform.json
+++ b/forgerock-am/amster/config/global/Platform.json
@@ -1,7 +1,7 @@
 {
   "metadata" : {
     "realm" : null,
-    "amsterVersion" : "6.5.1",
+    "amsterVersion" : "6.5.5",
     "entityType" : "Platform",
     "entityId" : "Platform",
     "pathParams" : { }


### PR DESCRIPTION
- Prepare for the next advisory patch
- Upgraded OB OpenAM from version 6.5.1 to version 6.5.5
Issue: https://github.com/forgecloud/ob-deploy/issues/925
