### PR TITLE
925: AM 6.5.1 security patch 202204

### DIFF
--- a/docker-compose-profiles.yml
+++ b/docker-compose-profiles.yml
@@ -350,8 +350,8 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.5-a7dd57885e7.war"
-        AMSTER_ZIP: "Amster-6.5.5-a7dd57885e7.zip"
+        AM_WAR_NAME: "OpenAM-6.5.1-68f2815add.war"
+        AMSTER_ZIP: "Amster-6.5.1.zip"
     image: openam:local
     container_name: openam
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,8 +332,8 @@ services:
       dockerfile: forgerock-am/Dockerfile
       args:
         # @see README file to get the binaries
-        AM_WAR_NAME: "OpenAM-6.5.5-a7dd57885e7.war"
-        AMSTER_ZIP: "Amster-6.5.5-a7dd57885e7.zip"
+        AM_WAR_NAME: "OpenAM-6.5.1-68f2815add.war"
+        AMSTER_ZIP: "Amster-6.5.1.zip"
     image: openam:local
     container_name: openam
     ports:

--- a/forgerock-am/Dockerfile
+++ b/forgerock-am/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y unzip && \
     mkdir -p /var/tmp/openam && \
     unzip -q /am.war -d /var/tmp/openam && \
-    if ! grep -q "com.iplanet.am.buildVersion=ForgeRock Access Management 6.5.5" /var/tmp/openam/WEB-INF/classes/serverdefaults.properties; then \
-    echo "ERROR: Provided war file is not AM version 6.5.5" && \
+    if ! grep -q "com.iplanet.am.buildVersion=ForgeRock Access Management 6.5.1" /var/tmp/openam/WEB-INF/classes/serverdefaults.properties; then \
+    echo "ERROR: Provided war file is not AM version 6.5.1" && \
     echo "VERSION FOUND: $(grep 'com.iplanet.am.buildVersion=' /var/tmp/openam/WEB-INF/classes/serverdefaults.properties)" && \
     exit 10; \
     fi && \

--- a/forgerock-am/README.md
+++ b/forgerock-am/README.md
@@ -11,9 +11,9 @@ cd openbanking-reference-implementation
 gsutil rsync gs://ob-forgerock-binaries/openam-local-binaries forgerock-am/_binaries
 ```
 ### Current AM war version files
-Source: [patches/6.5.5.1/openbanking](https://stash.forgerock.org/projects/OPENAM/repos/openam-customers/browse?at=refs%2Fheads%2Fpatches%2F6.5.5.1%2Fopenbanking)
-- OpenAM-6.5.5-a7dd57885e7.war
-- Amster-6.5.5-a7dd57885e7.zip
+Source: [patches/6.5.1.0/openbanking](https://stash.forgerock.org/projects/OPENAM/repos/openam-customers/browse?at=refs%2Fheads%2Fpatches%2F6.5.1.0%2Fopenbanking)
+- OpenAM-6.5.1-68f2815add.war
+- Amster-6.5.1.zip
 
 > The AM.war builds for Open Banking is from the customer branch with all patches integrated
 

--- a/forgerock-am/amster/config/global/Platform.json
+++ b/forgerock-am/amster/config/global/Platform.json
@@ -1,7 +1,7 @@
 {
   "metadata" : {
     "realm" : null,
-    "amsterVersion" : "6.5.5",
+    "amsterVersion" : "6.5.1",
     "entityType" : "Platform",
     "entityId" : "Platform",
     "pathParams" : { }


### PR DESCRIPTION
**Patch security advisor 202204**
- https://backstage.forgerock.com/knowledge/kb/article/a90639318
- Upgraded to use the new openam 6.5.1 patched with 202204 security advisor  
Issue: https://github.com/ForgeCloud/ob-deploy/issues/925
Relevant comment: https://github.com/ForgeCloud/ob-deploy/issues/925#issuecomment-1310519670