### PR TITLE
943: Remove non fapi compliant token-endpoint-auth-methods

### DIFF
--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/aspsp/as/as-api/as-api.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/aspsp/as/as-api/as-api.yml
@@ -19,7 +19,7 @@ metrics:
 
 dynamic-registration:
   enable: true
-  supported-token-endpoint-auth-method: "client_secret_post,private_key_jwt,client_secret_basic,tls_client_auth"
+  supported-token-endpoint-auth-method: "private_key_jwt,tls_client_auth"
 
 user-info.enable: true
 introspection.enable: true


### PR DESCRIPTION
Some offered methods were not FAPI compliant

Issue: https://github.com/forgecloud/ob-deploy/issues/943

