### PR TITLE
949 fix three letter country code mapping for latvia

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>4.8.1-SNAPSHOT</version>
+         <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>4.8.1</version>
+         <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1</version>
+        <version>4.8.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.1-SNAPSHOT</version>
+        <version>4.8.1</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -184,7 +184,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-reference-implementation.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-reference-implementation.git</url>
-        <tag>4.8.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>4.8.1-SNAPSHOT</version>
+    <version>4.8.1</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -184,7 +184,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-reference-implementation.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-reference-implementation.git</url>
-        <tag>HEAD</tag>
+        <tag>4.8.1</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
     <url>http://www.forgerock.com</url>
 
     <properties>
-        <ob-commons.version>1.5.1</ob-commons.version>
-        <ob-clients.version>1.5.1</ob-clients.version>
-        <ob-jwkms.version>1.5.1</ob-jwkms.version>
-        <ob-auth.version>1.5.1</ob-auth.version>
-        <ob-directory.version>1.7.2</ob-directory.version>
-        <ob-analytics.version>1.5.3</ob-analytics.version>
-        <ob-aspsp.version>2.1.2</ob-aspsp.version>
-        <ob-extensions.version>1.8.2</ob-extensions.version>
+        <ob-commons.version>1.5.2</ob-commons.version>
+        <ob-clients.version>1.5.2</ob-clients.version>
+        <ob-jwkms.version>1.5.2</ob-jwkms.version>
+        <ob-auth.version>1.5.2</ob-auth.version>
+        <ob-directory.version>1.7.3</ob-directory.version>
+        <ob-analytics.version>1.5.4</ob-analytics.version>
+        <ob-aspsp.version>2.1.3</ob-aspsp.version>
+        <ob-extensions.version>1.8.3</ob-extensions.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use latest v1.5.2 of the commons library and versions of library that also use that version. This fixes an issue with the TLA country code mapping that is use to reconstruct transport key's Organization Identifier from Open Banking Software Statements.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/949
