### PR TITLE
996: Support only ob v3.1.10 onward in master

### DIFF
--- a/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
+++ b/forgerock-openbanking-config/forgerock-openbanking-git-config/application.yml
@@ -96,6 +96,23 @@ rs:
       validation:
         enable: true
 
+  versions:
+    1.0: false
+    1.1: false
+    2.0: false
+    3.0: false
+    3.1: false
+    3.1.1: false
+    3.1.2: false
+    3.1.3: false
+    3.1.4: false
+    3.1.5: false
+    3.1.6: false
+    3.1.7: false
+    3.1.8: false
+    3.1.9: false
+    3.1.10: true
+
 rs-simulator:
   port: 443
   internal-port: 8443


### PR DESCRIPTION
Functional tests against all versions takes forever.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/996
