### PR TITLE
992: Release 4.8.3 - containing UI fix and newer jdk 11 slim baseimage

### DIFF
--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/forgerock-openbanking-as-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.as</groupId>
         <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-as/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - AS</name>
     <groupId>com.forgerock.openbanking.aspsp.as</groupId>
     <artifactId>forgerock-openbanking-aspsp-as</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-rcs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-simulator/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-store/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/forgerock-openbanking-rs-ui/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
         <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
+++ b/forgerock-openbanking-aspsp/forgerock-openbanking-aspsp-rs/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP - RS</name>
     <groupId>com.forgerock.openbanking.aspsp.rs</groupId>
     <artifactId>forgerock-openbanking-aspsp-rs</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.aspsp</groupId>
         <artifactId>forgerock-openbanking-aspsp</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-aspsp/pom.xml
+++ b/forgerock-openbanking-aspsp/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - ASPSP</name>
     <groupId>com.forgerock.openbanking.aspsp</groupId>
     <artifactId>forgerock-openbanking-aspsp</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-admin/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/forgerock-openbanking-metrics-services/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.metrics</groupId>
         <artifactId>forgerock-openbanking-metrics</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-metrics/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Metrics</name>
     <groupId>com.forgerock.openbanking.metrics</groupId>
     <artifactId>forgerock-openbanking-metrics</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
+++ b/forgerock-openbanking-backstage/forgerock-openbanking-monitoring/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.backstage</groupId>
         <artifactId>forgerock-openbanking-backstage</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-backstage/pom.xml
+++ b/forgerock-openbanking-backstage/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Reference Implementation - Backstage</name>
     <groupId>com.forgerock.openbanking.backstage</groupId>
     <artifactId>forgerock-openbanking-backstage</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-common/pom.xml
+++ b/forgerock-openbanking-common/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>4.8.3-SNAPSHOT</version>
+         <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-config/pom.xml
+++ b/forgerock-openbanking-config/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-         <version>4.8.3</version>
+         <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-docs/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
+++ b/forgerock-openbanking-devportal/forgerock-openbanking-register/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.devportal</groupId>
         <artifactId>forgerock-openbanking-devportal</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <properties>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-devportal/pom.xml
+++ b/forgerock-openbanking-devportal/pom.xml
@@ -27,13 +27,13 @@
     <name>ForgeRock OpenBanking Dev Portal</name>
     <groupId>com.forgerock.openbanking.devportal</groupId>
     <artifactId>forgerock-openbanking-devportal</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-directory-services/pom.xml
+++ b/forgerock-openbanking-directory-services/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-gateway/pom.xml
+++ b/forgerock-openbanking-gateway/pom.xml
@@ -34,7 +34,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3</version>
+        <version>4.8.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms/pom.xml
+++ b/forgerock-openbanking-jwkms/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-        <version>4.8.3-SNAPSHOT</version>
+        <version>4.8.3</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>4.8.3-SNAPSHOT</version>
+    <version>4.8.3</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -184,7 +184,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-reference-implementation.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-reference-implementation.git</url>
-        <tag>HEAD</tag>
+        <tag>4.8.3</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-reference-implementation</artifactId>
-    <version>4.8.3</version>
+    <version>4.8.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -184,7 +184,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-reference-implementation.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-reference-implementation.git</url>
-        <tag>4.8.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
## Description
Fix UI issue and create release using new base images
    
    Keep all the aspsp versions the same across our 4.8.3 release
    
Issues Fixed:
https://github.com/ForgeCloud/ob-deploy/issues/982
https://github.com/ForgeCloud/ob-deploy/issues/985

Issue: https://github.com/ForgeCloud/ob-deploy/issues/992




